### PR TITLE
Add a validate() method in message builders.

### DIFF
--- a/providence-core/src/main/java/net/morimekta/providence/PMessageBuilder.java
+++ b/providence-core/src/main/java/net/morimekta/providence/PMessageBuilder.java
@@ -36,6 +36,17 @@ public abstract class PMessageBuilder<T extends PMessage<T, F>, F extends PField
     public abstract boolean isValid();
 
     /**
+     * Checks if the current set data is enough to make a valid struct. It
+     * will check for all required fields, and if any are missing it will
+     * throw an {@link IllegalStateException} with an appropriate error
+     * message.
+     *
+     * @throws IllegalStateException When the builder will not generate a
+     *         valid message model object.
+     */
+    public abstract void validate() throws IllegalStateException;
+
+    /**
      * Set the provided field value.
      *
      * @param key The field key.

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/ApplicationException.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/ApplicationException.java
@@ -455,6 +455,10 @@ public class ApplicationException
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PExceptionDescriptor<ApplicationException,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/BinarySerializer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/BinarySerializer.java
@@ -266,6 +266,15 @@ public class BinarySerializer extends Serializer {
 
             fieldInfo = readFieldInfo(input);
         }
+
+        if (readStrict) {
+            try {
+                builder.validate();
+            } catch (IllegalStateException e) {
+                throw new SerializerException(e, e.getMessage());
+            }
+        }
+
         return builder.build();
     }
 

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/FastBinarySerializer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/FastBinarySerializer.java
@@ -214,6 +214,15 @@ public class FastBinarySerializer extends Serializer {
                 readFieldValue(in, tag, null);
             }
         }
+
+        if (readStrict) {
+            try {
+                builder.validate();
+            } catch (IllegalStateException e) {
+                throw new SerializerException(e, e.getMessage());
+            }
+        }
+
         return builder.build();
     }
 

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/JsonSerializer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/JsonSerializer.java
@@ -323,8 +323,12 @@ public class JsonSerializer extends Serializer {
             }
         }
 
-        if (readStrict && !builder.isValid()) {
-            throw new SerializerException("Type " + type.getName() + " not properly populated");
+        if (readStrict) {
+            try {
+                builder.validate();
+            } catch (IllegalStateException e) {
+                throw new SerializerException(e, e.getMessage());
+            }
         }
 
         return builder.build();
@@ -353,8 +357,12 @@ public class JsonSerializer extends Serializer {
             sep = tokenizer.expectSymbol("parsing compact message entry sep", JsonToken.kListEnd, JsonToken.kListSep);
         }
 
-        if (readStrict && !builder.isValid()) {
-            throw new SerializerException("Type " + type.getName() + " not properly populated");
+        if (readStrict) {
+            try {
+                builder.validate();
+            } catch (IllegalStateException e) {
+                throw new SerializerException(e, e.getMessage());
+            }
         }
 
         return builder.build();

--- a/providence-core/src/test/java/net/morimekta/test/calculator/CalculateException.java
+++ b/providence-core/src/test/java/net/morimekta/test/calculator/CalculateException.java
@@ -477,6 +477,22 @@ public class CalculateException
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(0)) {
+                    missing.add("message");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message calculator.CalculateException");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PExceptionDescriptor<CalculateException,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/calculator/Calculator.java
+++ b/providence-core/src/test/java/net/morimekta/test/calculator/Calculator.java
@@ -555,6 +555,10 @@ public class Calculator {
             }
 
             @Override
+            public void validate() {
+            }
+
+            @Override
             public net.morimekta.providence.descriptor.PStructDescriptor<Calculate_request,_Field> descriptor() {
                 return kDescriptor;
             }
@@ -1068,6 +1072,13 @@ public class Calculator {
             }
 
             @Override
+            public void validate() {
+                if (!isValid()) {
+                    throw new java.lang.IllegalStateException("No union field set in calculator.calculate___response");
+                }
+            }
+
+            @Override
             public net.morimekta.providence.descriptor.PUnionDescriptor<Calculate_response,_Field> descriptor() {
                 return kDescriptor;
             }
@@ -1338,6 +1349,10 @@ public class Calculator {
             @Override
             public boolean isValid() {
                 return true;
+            }
+
+            @Override
+            public void validate() {
             }
 
             @Override

--- a/providence-core/src/test/java/net/morimekta/test/calculator/Operand.java
+++ b/providence-core/src/test/java/net/morimekta/test/calculator/Operand.java
@@ -580,6 +580,13 @@ public class Operand
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                throw new java.lang.IllegalStateException("No union field set in calculator.Operand");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PUnionDescriptor<Operand,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/calculator/Operation.java
+++ b/providence-core/src/test/java/net/morimekta/test/calculator/Operation.java
@@ -458,6 +458,10 @@ public class Operation
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<Operation,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/number/Imaginary.java
+++ b/providence-core/src/test/java/net/morimekta/test/number/Imaginary.java
@@ -402,6 +402,22 @@ public class Imaginary
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(0)) {
+                    missing.add("v");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message number.Imaginary");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<Imaginary,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/CompactFields.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/CompactFields.java
@@ -507,6 +507,26 @@ public class CompactFields
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(0)) {
+                    missing.add("name");
+                }
+
+                if (!optionals.get(1)) {
+                    missing.add("id");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message providence.CompactFields");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<CompactFields,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/Containers.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/Containers.java
@@ -4497,6 +4497,10 @@ public class Containers
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<Containers,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/DefaultFields.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/DefaultFields.java
@@ -1034,6 +1034,10 @@ public class DefaultFields
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<DefaultFields,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/DefaultValues.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/DefaultValues.java
@@ -1036,6 +1036,10 @@ public class DefaultValues
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<DefaultValues,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/ExceptionFields.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/ExceptionFields.java
@@ -1114,6 +1114,10 @@ public class ExceptionFields
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PExceptionDescriptor<ExceptionFields,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/OptionalFields.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/OptionalFields.java
@@ -1091,6 +1091,10 @@ public class OptionalFields
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<OptionalFields,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/RequiredFields.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/RequiredFields.java
@@ -1043,6 +1043,58 @@ public class RequiredFields
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(0)) {
+                    missing.add("booleanValue");
+                }
+
+                if (!optionals.get(1)) {
+                    missing.add("byteValue");
+                }
+
+                if (!optionals.get(2)) {
+                    missing.add("shortValue");
+                }
+
+                if (!optionals.get(3)) {
+                    missing.add("integerValue");
+                }
+
+                if (!optionals.get(4)) {
+                    missing.add("longValue");
+                }
+
+                if (!optionals.get(5)) {
+                    missing.add("doubleValue");
+                }
+
+                if (!optionals.get(6)) {
+                    missing.add("stringValue");
+                }
+
+                if (!optionals.get(7)) {
+                    missing.add("binaryValue");
+                }
+
+                if (!optionals.get(8)) {
+                    missing.add("enumValue");
+                }
+
+                if (!optionals.get(9)) {
+                    missing.add("compactValue");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message providence.RequiredFields");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<RequiredFields,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-core/src/test/java/net/morimekta/test/providence/UnionFields.java
+++ b/providence-core/src/test/java/net/morimekta/test/providence/UnionFields.java
@@ -1094,6 +1094,13 @@ public class UnionFields
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                throw new java.lang.IllegalStateException("No union field set in providence.UnionFields");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PUnionDescriptor<UnionFields,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CException.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CException.java
@@ -26,6 +26,7 @@ import net.morimekta.providence.descriptor.PField;
 import net.morimekta.providence.descriptor.PList;
 import net.morimekta.providence.descriptor.PMap;
 import net.morimekta.providence.descriptor.PPrimitive;
+import net.morimekta.providence.descriptor.PRequirement;
 import net.morimekta.providence.descriptor.PSet;
 import net.morimekta.providence.descriptor.PStructDescriptor;
 
@@ -245,6 +246,25 @@ public class CException extends Throwable implements PMessage<CException, CField
         @Override
         public boolean isValid() {
             return values.size() == 1;
+        }
+
+        @Override
+        public void validate() {
+            LinkedList<String> missing = new LinkedList<>();
+            for (PField field : descriptor.getFields()) {
+                if (field.getRequirement() == PRequirement.REQUIRED) {
+                    if (!values.containsKey(field.getKey())) {
+                        missing.add(field.getName());
+                    }
+                }
+            }
+
+            if (missing.size() > 0) {
+                throw new IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message " + descriptor().getQualifiedName(null));
+            }
         }
 
         @Override

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CStruct.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CStruct.java
@@ -32,6 +32,7 @@ import net.morimekta.providence.descriptor.PStructDescriptor;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -146,6 +147,25 @@ public class CStruct extends CMessage<CStruct,CField> {
             }
 
             return true;
+        }
+
+        @Override
+        public void validate() {
+            LinkedList<String> missing = new LinkedList<>();
+            for (PField field : descriptor.getFields()) {
+                if (field.getRequirement() == PRequirement.REQUIRED) {
+                    if (!values.containsKey(field.getKey())) {
+                        missing.add(field.getName());
+                    }
+                }
+            }
+
+            if (missing.size() > 0) {
+                throw new IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message " + descriptor().getQualifiedName(null));
+            }
         }
 
         @Override

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CUnion.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CUnion.java
@@ -167,6 +167,14 @@ public class CUnion extends CMessage<CUnion,CField> implements PUnion<CUnion,CFi
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                throw new IllegalStateException("No union field set in " +
+                                                descriptor().getQualifiedName(null));
+            }
+        }
+
+        @Override
         public Builder set(int key, Object value) {
             CField field = descriptor.getField(key);
             if (field == null) {

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/Declaration.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/Declaration.java
@@ -825,6 +825,13 @@ public class Declaration
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                throw new java.lang.IllegalStateException("No union field set in model.Declaration");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PUnionDescriptor<Declaration,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/EnumType.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/EnumType.java
@@ -663,6 +663,22 @@ public class EnumType
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(1)) {
+                    missing.add("name");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message model.EnumType");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<EnumType,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/EnumValue.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/EnumValue.java
@@ -613,6 +613,22 @@ public class EnumValue
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(1)) {
+                    missing.add("name");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message model.EnumValue");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<EnumValue,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/ServiceMethod.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/ServiceMethod.java
@@ -929,6 +929,22 @@ public class ServiceMethod
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(3)) {
+                    missing.add("name");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message model.ServiceMethod");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<ServiceMethod,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/ServiceType.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/ServiceType.java
@@ -745,6 +745,22 @@ public class ServiceType
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(1)) {
+                    missing.add("name");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message model.ServiceType");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<ServiceType,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/StructType.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/StructType.java
@@ -745,6 +745,22 @@ public class StructType
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(2)) {
+                    missing.add("name");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message model.StructType");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<StructType,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/ThriftDocument.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/ThriftDocument.java
@@ -820,6 +820,22 @@ public class ThriftDocument
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(1)) {
+                    missing.add("package");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message model.ThriftDocument");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<ThriftDocument,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/ThriftField.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/ThriftField.java
@@ -865,6 +865,30 @@ public class ThriftField
         }
 
         @Override
+        public void validate() {
+            if (!isValid()) {
+                java.util.LinkedList<String> missing = new java.util.LinkedList<>();
+
+                if (!optionals.get(1)) {
+                    missing.add("key");
+                }
+
+                if (!optionals.get(3)) {
+                    missing.add("type");
+                }
+
+                if (!optionals.get(4)) {
+                    missing.add("name");
+                }
+
+                throw new java.lang.IllegalStateException(
+                        "Missing required fields " +
+                        String.join(",", missing) +
+                        " in message model.ThriftField");
+            }
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<ThriftField,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-reflect/src/main/model/net/morimekta/providence/model/TypedefType.java
+++ b/providence-reflect/src/main/model/net/morimekta/providence/model/TypedefType.java
@@ -508,6 +508,10 @@ public class TypedefType
         }
 
         @Override
+        public void validate() {
+        }
+
+        @Override
         public net.morimekta.providence.descriptor.PStructDescriptor<TypedefType,_Field> descriptor() {
             return kDescriptor;
         }

--- a/providence-thrift/src/main/java/net/morimekta/providence/thrift/TProtocolSerializer.java
+++ b/providence-thrift/src/main/java/net/morimekta/providence/thrift/TProtocolSerializer.java
@@ -261,8 +261,12 @@ class TProtocolSerializer extends Serializer {
         }
         protocol.readStructEnd();
 
-        if (!builder.isValid() && readStrict) {
-            throw new SerializerException("Read invalid message from protocol");
+        if (readStrict) {
+            try {
+                builder.validate();
+            } catch (IllegalStateException e) {
+                throw new SerializerException(e, e.getMessage());
+            }
         }
 
         return builder.build();

--- a/providence-thrift/src/main/java/net/morimekta/providence/thrift/TTupleProtocolSerializer.java
+++ b/providence-thrift/src/main/java/net/morimekta/providence/thrift/TTupleProtocolSerializer.java
@@ -257,8 +257,12 @@ public class TTupleProtocolSerializer extends Serializer {
             }
         }
 
-        if (readStrict && !builder.isValid()) {
-            throw new SerializerException("");
+        if (readStrict) {
+            try {
+                builder.validate();
+            } catch (IllegalStateException e) {
+                throw new SerializerException(e, e.getMessage());
+            }
         }
 
         return builder.build();


### PR DESCRIPTION
This will throw an  exception with a more explicit message about why it
is not valid. Handy for getting readable error messages from
serializers.