### PR TITLE
Overhauling the const parsing in thrift files.

### DIFF
--- a/providence-config/src/main/java/net/morimekta/providence/config/ProvidenceConfig.java
+++ b/providence-config/src/main/java/net/morimekta/providence/config/ProvidenceConfig.java
@@ -131,8 +131,7 @@ public class ProvidenceConfig {
             } else if (value instanceof PEnumValue) {
                 return String.format("%s = %s.%s (%s)",
                                      name,
-                                     ((PEnumValue) value).descriptor()
-                                                         .getQualifiedName(null),
+                                     ((PEnumValue) value).descriptor().getQualifiedName(),
                                      asString(value),
                                      file.getName());
             } else if (value instanceof CharSequence) {
@@ -552,7 +551,7 @@ public class ProvidenceConfig {
 
             F field = descriptor.getField(token.asString());
             if (field == null) {
-                throw new TokenizerException("No such field " + token.asString() + " in " + descriptor.getQualifiedName(null))
+                throw new TokenizerException("No such field " + token.asString() + " in " + descriptor.getQualifiedName())
                         .setLine(tokenizer.getLine(token.getLineNo()));
             }
 

--- a/providence-config/src/main/java/net/morimekta/providence/config/ProvidenceConfigUtil.java
+++ b/providence-config/src/main/java/net/morimekta/providence/config/ProvidenceConfigUtil.java
@@ -72,20 +72,20 @@ public class ProvidenceConfigUtil {
 
             PField field = descriptor.getField(name);
             if (field == null) {
-                throw new KeyNotFoundException("Message " + message.descriptor().getQualifiedName(null) + " has no field named " +
+                throw new KeyNotFoundException("Message " + message.descriptor().getQualifiedName() + " has no field named " +
                                                name);
             }
             PDescriptor fieldDesc = field.getDescriptor();
             if (fieldDesc.getType() != PType.MESSAGE) {
                 throw new IncompatibleValueException("Field " + name + " is not of message type in " +
-                                                     descriptor.getQualifiedName(null));
+                                                     descriptor.getQualifiedName());
             }
 
             if (!message.has(field.getKey())) {
                 while (sub.contains(".")) {
                     if (fieldDesc.getType() != PType.MESSAGE) {
                         throw new IncompatibleValueException("Field " + name + " is not of message type in " +
-                                                             descriptor.getQualifiedName(null));
+                                                             descriptor.getQualifiedName());
                     }
 
                     idx = sub.indexOf(".");
@@ -102,7 +102,7 @@ public class ProvidenceConfigUtil {
 
         PField field = message.descriptor().getField(key);
         if (field == null) {
-            throw new KeyNotFoundException("Message " + message.descriptor().getQualifiedName(null) + " has no field named " +
+            throw new KeyNotFoundException("Message " + message.descriptor().getQualifiedName() + " has no field named " +
                                            key);
         }
 

--- a/providence-core/src/main/java/net/morimekta/providence/descriptor/PContainer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/descriptor/PContainer.java
@@ -47,7 +47,7 @@ public abstract class PContainer<Container> implements PDescriptor {
 
     @Override
     public String toString() {
-        return getQualifiedName(null);
+        return getQualifiedName();
     }
 
     /**

--- a/providence-core/src/main/java/net/morimekta/providence/descriptor/PDeclaredDescriptor.java
+++ b/providence-core/src/main/java/net/morimekta/providence/descriptor/PDeclaredDescriptor.java
@@ -54,7 +54,7 @@ public abstract class PDeclaredDescriptor<T> implements PDescriptor {
 
     @Override
     public String toString() {
-        return getQualifiedName(null);
+        return getQualifiedName();
     }
 
     /**

--- a/providence-core/src/main/java/net/morimekta/providence/descriptor/PDescriptor.java
+++ b/providence-core/src/main/java/net/morimekta/providence/descriptor/PDescriptor.java
@@ -55,6 +55,15 @@ public interface PDescriptor {
     String getQualifiedName(String programContext);
 
     /**
+     * This will return the globally qualified name of the type given the program context.
+     *
+     * @return The qualified name of the type, including program name.
+     */
+    default String getQualifiedName() {
+        return getQualifiedName(null);
+    }
+
+    /**
      * @return Get the field type.
      */
     PType getType();

--- a/providence-core/src/main/java/net/morimekta/providence/descriptor/PEnumDescriptor.java
+++ b/providence-core/src/main/java/net/morimekta/providence/descriptor/PEnumDescriptor.java
@@ -69,7 +69,7 @@ public abstract class PEnumDescriptor<T extends PEnumValue<T>> extends PDeclared
 
     @Override
     public String toString() {
-        return getQualifiedName(null);
+        return getQualifiedName();
     }
 
     @Override
@@ -78,7 +78,7 @@ public abstract class PEnumDescriptor<T extends PEnumValue<T>> extends PDeclared
             return false;
         }
         PEnumDescriptor<?> other = (PEnumDescriptor<?>) o;
-        if (!getQualifiedName(null).equals(other.getQualifiedName(null)) ||
+        if (!getQualifiedName().equals(other.getQualifiedName()) ||
             getValues().length != other.getValues().length) {
             return false;
         }
@@ -94,7 +94,7 @@ public abstract class PEnumDescriptor<T extends PEnumValue<T>> extends PDeclared
 
     @Override
     public int hashCode() {
-        return Objects.hash(PEnumDescriptor.class, getQualifiedName(null));
+        return Objects.hash(PEnumDescriptor.class, getQualifiedName());
     }
 
     protected PEnumBuilderFactory<T> getFactoryInternal() {

--- a/providence-core/src/main/java/net/morimekta/providence/descriptor/PField.java
+++ b/providence-core/src/main/java/net/morimekta/providence/descriptor/PField.java
@@ -81,7 +81,7 @@ public interface PField {
         if (field.getRequirement() != net.morimekta.providence.descriptor.PRequirement.DEFAULT) {
             builder.append(field.getRequirement().label).append(" ");
         }
-        builder.append(field.getDescriptor().getQualifiedName(null))
+        builder.append(field.getDescriptor().getQualifiedName())
                .append(' ')
                .append(field.getName())
                .append(')');

--- a/providence-core/src/main/java/net/morimekta/providence/descriptor/PStructDescriptor.java
+++ b/providence-core/src/main/java/net/morimekta/providence/descriptor/PStructDescriptor.java
@@ -101,7 +101,7 @@ public abstract class PStructDescriptor<T extends PMessage<T, F>, F extends PFie
             return false;
         }
         PStructDescriptor<?, ?> other = (PStructDescriptor<?, ?>) o;
-        if (!getQualifiedName(null).equals(other.getQualifiedName(null)) ||
+        if (!getQualifiedName().equals(other.getQualifiedName()) ||
             !getVariant().equals(other.getVariant()) ||
             getFields().length != other.getFields().length) {
             return false;
@@ -117,7 +117,7 @@ public abstract class PStructDescriptor<T extends PMessage<T, F>, F extends PFie
     @Override
     public int hashCode() {
         int hash = PStructDescriptor.class.hashCode() +
-                   getQualifiedName(null).hashCode() +
+                   getQualifiedName().hashCode() +
                    getVariant().hashCode();
         for (PField field : getFields()) {
             hash += field.hashCode();

--- a/providence-core/src/main/java/net/morimekta/providence/descriptor/PStructDescriptor.java
+++ b/providence-core/src/main/java/net/morimekta/providence/descriptor/PStructDescriptor.java
@@ -33,12 +33,12 @@ public abstract class PStructDescriptor<T extends PMessage<T, F>, F extends PFie
     private final boolean                      compactible;
     private final boolean                      simple;
 
-    public PStructDescriptor(String packageName,
+    public PStructDescriptor(String programName,
                              String name,
                              PMessageBuilderFactory<T, F> factory,
                              boolean simple,
                              boolean compactible) {
-        super(packageName, name);
+        super(programName, name);
 
         this.factory = factory;
         this.simple = simple;

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/BinarySerializer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/BinarySerializer.java
@@ -255,7 +255,7 @@ public class BinarySerializer extends Serializer {
             } else {
                 if (readStrict) {
                     throw new SerializerException(
-                            "Unknown field " + fieldInfo.getId() + " for type " + descriptor.getQualifiedName(null));
+                            "Unknown field " + fieldInfo.getId() + " for type " + descriptor.getQualifiedName());
                 }
                 readFieldValue(input, fieldInfo, null);
             }

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/FastBinarySerializer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/FastBinarySerializer.java
@@ -209,7 +209,7 @@ public class FastBinarySerializer extends Serializer {
             } else {
                 if (readStrict) {
                     throw new SerializerException(
-                            "Unknown field ID %d in type %s", id, descriptor.getQualifiedName(null));
+                            "Unknown field ID %d in type %s", id, descriptor.getQualifiedName());
                 }
                 readFieldValue(in, tag, null);
             }

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/JsonSerializer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/JsonSerializer.java
@@ -314,7 +314,7 @@ public class JsonSerializer extends Serializer {
                     Object value = parseTypedValue(tokenizer.expect("parsing message field value"), tokenizer, field.getDescriptor());
                     builder.set(field.getKey(), value);
                 } else if (readStrict) {
-                    throw new SerializerException("Unknown field " + key + " for type " + type.getQualifiedName(null));
+                    throw new SerializerException("Unknown field " + key + " for type " + type.getQualifiedName());
                 } else {
                     consume(tokenizer.expect("consuming unknown message value"), tokenizer);
                 }
@@ -349,7 +349,7 @@ public class JsonSerializer extends Serializer {
                 builder.set(i, value);
             } else if (readStrict) {
                 throw new SerializerException("Compact Field ID " + (i) + " outside field spectrum for type " +
-                                              type.getQualifiedName(null));
+                                              type.getQualifiedName());
             } else {
                 consume(tokenizer.expect("consuming compact message field value"), tokenizer);
             }
@@ -543,10 +543,10 @@ public class JsonSerializer extends Serializer {
         } catch (JsonException je) {
             throw new SerializerException(je, "Unable to parse type value.");
         } catch (ClassCastException ce) {
-            throw new SerializerException(ce, "Serialized type  not compatible with " + t.getQualifiedName(null));
+            throw new SerializerException(ce, "Serialized type  not compatible with " + t.getQualifiedName());
         }
 
-        throw new SerializerException("Unhandled item type " + t.getQualifiedName(null));
+        throw new SerializerException("Unhandled item type " + t.getQualifiedName());
     }
 
     private Object parseMapKey(String key, PDescriptor keyType) throws SerializerException {
@@ -592,14 +592,14 @@ public class JsonSerializer extends Serializer {
                     }
                     if (readStrict && !eb.isValid()) {
                         throw new SerializerException("%s is not a valid enum value for %s",
-                                                      key, keyType.getQualifiedName(null));
+                                                      key, keyType.getQualifiedName());
                     }
                     return eb.build();
                 case MESSAGE:
                     PStructDescriptor<?, ?> st = (PStructDescriptor<?, ?>) keyType;
                     if (!st.isSimple()) {
                         throw new SerializerException("Only simple structs can be used as map key. %s is not.",
-                                                      st.getQualifiedName(null));
+                                                      st.getQualifiedName());
                     }
                     ByteArrayInputStream input = new ByteArrayInputStream(key.getBytes(StandardCharsets.UTF_8));
                     try {
@@ -738,7 +738,7 @@ public class JsonSerializer extends Serializer {
             if (!message.descriptor().isSimple()) {
                 throw new SerializerException("Only simple messages can be used as map keys. " +
                                               message.descriptor()
-                                                     .getQualifiedName(null) + " is not.");
+                                                     .getQualifiedName() + " is not.");
             }
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             JsonWriter json = new JsonWriter(baos);

--- a/providence-core/src/main/java/net/morimekta/providence/serializer/PrettySerializer.java
+++ b/providence-core/src/main/java/net/morimekta/providence/serializer/PrettySerializer.java
@@ -234,7 +234,7 @@ public class PrettySerializer extends Serializer {
             }
             PField field = descriptor.getField(t.asString());
             if (field == null) {
-                throw new TokenizerException(t, "No such field %s on %s", t.asString(), descriptor.getQualifiedName(null))
+                throw new TokenizerException(t, "No such field %s on %s", t.asString(), descriptor.getQualifiedName())
                         .setLine(tokenizer.getLine(t.getLineNo()));
             }
 
@@ -380,7 +380,7 @@ public class PrettySerializer extends Serializer {
                 PEnumBuilder b = ((PEnumDescriptor) descriptor).builder();
                 b.setByName(t.asString());
                 if (!b.isValid()) {
-                    throw new TokenizerException(t, "No such " + descriptor.getQualifiedName(null) + " value " + t.asString())
+                    throw new TokenizerException(t, "No such " + descriptor.getQualifiedName() + " value " + t.asString())
                             .setLine(tokenizer.getLine(t.getLineNo()));
                 }
                 return b.build();

--- a/providence-core/src/main/java/net/morimekta/providence/util/TypeRegistry.java
+++ b/providence-core/src/main/java/net/morimekta/providence/util/TypeRegistry.java
@@ -97,7 +97,7 @@ public class TypeRegistry {
      * @param <T> The descriptor object type.
      */
     public <T> void putDeclaredType(PDeclaredDescriptor<T> declaredType) {
-        String declaredTypeName = declaredType.getQualifiedName(null);
+        String declaredTypeName = declaredType.getQualifiedName();
         if (declaredTypes.containsKey(declaredTypeName)) {
             throw new IllegalStateException("Type " + declaredTypeName + " already exists");
         }
@@ -143,7 +143,7 @@ public class TypeRegistry {
      * @param <T> The declared java type.
      */
     public <T> void registerRecursively(PDeclaredDescriptor<T> declaredType) {
-        String declaredTypeName = declaredType.getQualifiedName(null);
+        String declaredTypeName = declaredType.getQualifiedName();
         if (declaredTypes.containsKey(declaredTypeName)) {
             return;
         }

--- a/providence-core/src/test/java/net/morimekta/providence/descriptor/PDeclaredDescriptorTest.java
+++ b/providence-core/src/test/java/net/morimekta/providence/descriptor/PDeclaredDescriptorTest.java
@@ -46,11 +46,12 @@ public class PDeclaredDescriptorTest {
     }
 
     @Test
-    public void testGetName() {
+    public void testGetQualifiedName() {
         assertEquals("MockDescriptor", mockType.getName());
         assertEquals("MockDescriptor", mockType.getQualifiedName("test"));
         assertEquals("test.MockDescriptor", mockType.getQualifiedName("not_test"));
         assertEquals("test.MockDescriptor", mockType.getQualifiedName(null));
+        assertEquals("test.MockDescriptor", mockType.getQualifiedName());
     }
 
     @Test

--- a/providence-core/src/test/java/net/morimekta/providence/descriptor/PPrimitiveTest.java
+++ b/providence-core/src/test/java/net/morimekta/providence/descriptor/PPrimitiveTest.java
@@ -47,14 +47,14 @@ public class PPrimitiveTest {
 
     @Test
     public void testGetName_noPackage() {
-        assertEquals("bool", PPrimitive.BOOL.getQualifiedName(null));
-        assertEquals("byte", PPrimitive.BYTE.getQualifiedName(null));
-        assertEquals("i16", PPrimitive.I16.getQualifiedName(null));
-        assertEquals("i32", PPrimitive.I32.getQualifiedName(null));
-        assertEquals("i64", PPrimitive.I64.getQualifiedName(null));
-        assertEquals("double", PPrimitive.DOUBLE.getQualifiedName(null));
-        assertEquals("string", PPrimitive.STRING.getQualifiedName(null));
-        assertEquals("binary", PPrimitive.BINARY.getQualifiedName(null));
+        assertEquals("bool", PPrimitive.BOOL.getQualifiedName());
+        assertEquals("byte", PPrimitive.BYTE.getQualifiedName());
+        assertEquals("i16", PPrimitive.I16.getQualifiedName());
+        assertEquals("i32", PPrimitive.I32.getQualifiedName());
+        assertEquals("i64", PPrimitive.I64.getQualifiedName());
+        assertEquals("double", PPrimitive.DOUBLE.getQualifiedName());
+        assertEquals("string", PPrimitive.STRING.getQualifiedName());
+        assertEquals("binary", PPrimitive.BINARY.getQualifiedName());
     }
 
     @Test

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/JavaConstantsFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/JavaConstantsFormatter.java
@@ -1,22 +1,13 @@
 package net.morimekta.providence.generator.format.java;
 
-import net.morimekta.providence.PMessage;
-import net.morimekta.providence.descriptor.PContainer;
-import net.morimekta.providence.descriptor.PDescriptor;
-import net.morimekta.providence.descriptor.PField;
-import net.morimekta.providence.descriptor.PMap;
 import net.morimekta.providence.generator.GeneratorException;
 import net.morimekta.providence.generator.format.java.shared.BaseConstantsFormatter;
 import net.morimekta.providence.generator.format.java.utils.BlockCommentBuilder;
-import net.morimekta.providence.generator.format.java.utils.JField;
 import net.morimekta.providence.generator.format.java.utils.JHelper;
 import net.morimekta.providence.generator.format.java.utils.ValueBuilder;
 import net.morimekta.providence.reflect.contained.CField;
 import net.morimekta.providence.reflect.contained.CProgram;
 import net.morimekta.util.io.IndentedPrintWriter;
-
-import java.util.Collection;
-import java.util.Map;
 
 /**
  * @author Stein Eldar Johnsen
@@ -53,104 +44,20 @@ public class JavaConstantsFormatter implements BaseConstantsFormatter {
 
             try {
                 String name = c.getName();
-                JField constant = new JField(c, helper, 1);
-                switch (c.getType()) {
-                    case MESSAGE: {
-                        String instance = helper.getValueType(c.getDescriptor());
-                        writer.formatln("public static final %s %s;", helper.getValueType(c.getDescriptor()), name)
-                              .appendln("static {")
-                              .begin()
-                              .formatln("%s = %s.builder()", name, instance)
-                              .begin(DBL_INDENT);
 
-                        PMessage<?, ?> message = (PMessage<?, ?>) c.getDefaultValue();
-                        int i = 0;
-                        for (PField f : message.descriptor()
-                                               .getFields()) {
-                            CField cField = (CField) f;
-                            JField field = new JField(cField, helper, i++);
-                            if (message.has(f.getKey())) {
-                                writer.formatln(".%s(", field.setter());
-                                value.appendTypedValue(message.get(f.getKey()), f.getDescriptor());
-                                writer.append(")");
-                            }
-                        }
+                writer.formatln("public static final %s %s;", helper.getValueType(c.getDescriptor()), name)
+                      .appendln("static {")
+                      .begin()
+                      .formatln("%s = ", name)
+                      .begin();
 
-                        writer.formatln(".build();", name)
-                              .end()
-                              .end()
-                              .appendln('}');
-                        break;
-                    }
-                    case LIST:
-                    case SET: {
-                        PContainer<?> lDesc = (PContainer<?>) c.getDescriptor();
-                        PDescriptor itemDesc = lDesc.itemDescriptor();
+                value.appendTypedValue(c.getDefaultValue(), c.getDescriptor());
 
-                        writer.formatln("public static final %s %s;", helper.getValueType(c.getDescriptor()), name)
-                              .appendln("static {")
-                              .begin()
-                              .formatln("%s = new %s<%s>()", name, constant.builderInstanceType(), helper.getFieldType(itemDesc))
-                              .begin(DBL_INDENT);
+                writer.append(';')
+                      .end()
+                      .appendln('}')
+                      .end();
 
-                        @SuppressWarnings("unchecked")
-                        Collection<Object> items = (Collection<Object>) c.getDefaultValue();
-                        for (Object item : items) {
-                            writer.appendln(".add(")
-                                  .begin();
-
-                            value.appendTypedValue(item, itemDesc);
-
-                            writer.end()
-                                  .append(")");
-                        }
-
-                        writer.formatln(".build();", name);
-                        writer.end()
-                              .end()
-                              .appendln('}');
-                        break;
-                    }
-                    case MAP: {
-                        PMap<?, ?> mDesc = (PMap<?, ?>) c.getDescriptor();
-                        PDescriptor itemDesc = mDesc.itemDescriptor();
-                        PDescriptor keyDesc = mDesc.keyDescriptor();
-
-                        writer.formatln("public static final %s %s;", helper.getValueType(c.getDescriptor()), name)
-                              .appendln("static {")
-                              .begin()
-                              .formatln("%s = new %s<>()", name, constant.builderInstanceType())
-                              .begin(DBL_INDENT);
-
-                        @SuppressWarnings("unchecked")
-                        Map<Object, Object> items = (Map<Object, Object>) c.getDefaultValue();
-                        for (Map.Entry<Object, Object> item : items.entrySet()) {
-                            writer.appendln(".put(")
-                                  .begin();
-
-                            value.appendTypedValue(item.getKey(), keyDesc);
-
-                            writer.append(", ");
-
-                            value.appendTypedValue(item.getValue(), itemDesc);
-
-                            writer.end()
-                                  .append(")");
-                        }
-
-                        writer.formatln(".build();", name);
-                        writer.end()
-                              .end()
-                              .appendln('}');
-                        break;
-                    }
-                    default:
-                        writer.formatln("public static final %s %s = ", helper.getValueType(c.getDescriptor()), c.getName())
-                              .begin(DBL_INDENT);
-                        value.appendTypedValue(c.getDefaultValue(), c.getDescriptor());
-                        writer.append(';')
-                              .end();
-                }
             } catch (Exception e) {
                 throw new GeneratorException("Unable to generate constant " + document.getProgramName() + "." + c.getName(),
                                              e);

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/enums/extras/JacksonEnumFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/enums/extras/JacksonEnumFormatter.java
@@ -68,7 +68,7 @@ public class JacksonEnumFormatter implements EnumMemberFormatter {
               .appendln("        } else {")
               .formatln("            throw new %s(jp, \"Invalid token for enum %s deserialization \" + jp.getText());",
                         JsonParseException.class.getName(),
-                        type.getQualifiedName(null))
+                        type.getQualifiedName())
               .appendln("        }")
               .appendln("    }")
               .appendln('}')

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/BuilderCommonMemberFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/BuilderCommonMemberFormatter.java
@@ -109,7 +109,7 @@ public class BuilderCommonMemberFormatter implements MessageMemberFormatter {
 
     private void appendDefaultConstructor(JMessage<?> message) throws GeneratorException {
         BlockCommentBuilder comment = new BlockCommentBuilder(writer);
-        comment.comment("Make a " + message.descriptor().getQualifiedName(null) + " builder.")
+        comment.comment("Make a " + message.descriptor().getQualifiedName() + " builder.")
                .finish();
         writer.appendln("public _Builder() {")
               .begin();
@@ -134,7 +134,7 @@ public class BuilderCommonMemberFormatter implements MessageMemberFormatter {
 
     private void appendMutateConstructor(JMessage<?> message) {
         BlockCommentBuilder comment = new BlockCommentBuilder(writer);
-        comment.comment("Make a mutating builder off a base " + message.descriptor().getQualifiedName(null) + ".")
+        comment.comment("Make a mutating builder off a base " + message.descriptor().getQualifiedName() + ".")
                .newline()
                .param_("base", "The base " + message.descriptor().getName())
                .finish();

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/BuilderCoreOverridesFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/BuilderCoreOverridesFormatter.java
@@ -324,7 +324,7 @@ public class BuilderCoreOverridesFormatter implements MessageMemberFormatter {
             writer.appendln("if (!isValid()) {")
                   .formatln("    throw new %s(\"No union field set in %s\");",
                             IllegalStateException.class.getName(),
-                            message.descriptor().getQualifiedName(null))
+                            message.descriptor().getQualifiedName())
                   .appendln("}");
         } else {
             boolean hasRequired =
@@ -353,7 +353,7 @@ public class BuilderCoreOverridesFormatter implements MessageMemberFormatter {
                 writer.formatln("throw new %s(", IllegalStateException.class.getName())
                       .appendln("        \"Missing required fields \" +")
                       .appendln("        String.join(\",\", missing) +")
-                      .formatln("        \" in message %s\");", message.descriptor().getQualifiedName(null))
+                      .formatln("        \" in message %s\");", message.descriptor().getQualifiedName())
                       .end()
                       .appendln("}");
             }

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonBuilderFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonBuilderFormatter.java
@@ -66,7 +66,7 @@ public class CommonBuilderFormatter
 
     protected void appendStaticMakeBuilder(JMessage message) {
         BlockCommentBuilder comment = new BlockCommentBuilder(writer);
-        comment.comment("Make a " + message.descriptor().getQualifiedName(null) + " builder.")
+        comment.comment("Make a " + message.descriptor().getQualifiedName() + " builder.")
                .return_("The builder instance.")
                .finish();
         writer.formatln("public static _Builder builder() {")

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonMemberFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonMemberFormatter.java
@@ -191,7 +191,7 @@ public class CommonMemberFormatter implements MessageMemberFormatter {
                     writer.append(',')
                           .appendln();
                 }
-                writer.format("%s %s", fld.valueType(), fld.param());
+                writer.format("%s %s", fld.fieldType(), fld.param());
             }
         }
 

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonOverridesFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonOverridesFormatter.java
@@ -141,7 +141,7 @@ public class CommonOverridesFormatter implements MessageMemberFormatter {
               .begin()
               .formatln("return \"%s\" + asString();",
                         message.descriptor()
-                               .getQualifiedName(null))
+                               .getQualifiedName())
               .end()
               .appendln('}')
               .newline();

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/JUtils.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/JUtils.java
@@ -36,7 +36,7 @@ import java.io.File;
 public class JUtils {
     public static long generateSerialVersionUID(PStructDescriptor<?, ?> type) {
         String string = type.getVariant()
-                            .getName() + " " + type.getQualifiedName(null);
+                            .getName() + " " + type.getQualifiedName();
 
         long hash = 1125899906842597L; // prime
         final int len = string.length();

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/ValueBuilder.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/ValueBuilder.java
@@ -8,7 +8,7 @@ import net.morimekta.providence.descriptor.PMap;
 import net.morimekta.providence.generator.GeneratorException;
 import net.morimekta.providence.reflect.contained.CConst;
 import net.morimekta.providence.reflect.contained.CField;
-import net.morimekta.providence.reflect.contained.CStructDescriptor;
+import net.morimekta.providence.reflect.contained.CMessageDescriptor;
 import net.morimekta.util.Binary;
 import net.morimekta.util.io.IndentedPrintWriter;
 import net.morimekta.util.json.JsonException;
@@ -109,7 +109,7 @@ public class ValueBuilder {
                       .begin();
                 PMessage message = (PMessage) value;
                 int i = 0;
-                for (CField field : ((CStructDescriptor) type).getFields()) {
+                for (CField field : ((CMessageDescriptor) type).getFields()) {
                     JField fld = new JField(field, helper, i++);
                     if (message.has(field.getKey())) {
                         writer.formatln(".%s(", fld.setter());
@@ -132,7 +132,7 @@ public class ValueBuilder {
                                 constant.builderInstanceType(),
                                 helper.getFieldType(keyDesc),
                                 helper.getFieldType(itemDesc))
-                      .begin("        ");
+                      .begin();
 
                 @SuppressWarnings("unchecked")
                 Map<Object, Object> map = (Map<Object, Object>) value;
@@ -162,7 +162,7 @@ public class ValueBuilder {
                 JField constant = new JField(new CConst("", "", () -> type, () -> value, null), helper, 0);
 
                 writer.formatln("new %s<%s>()", constant.builderInstanceType(), helper.getFieldType(itemDesc))
-                      .begin("        ");
+                      .begin();
 
                 @SuppressWarnings("unchecked")
                 Collection<Object> items = (Collection<Object>) value;

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/ValueBuilder.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/ValueBuilder.java
@@ -128,7 +128,7 @@ public class ValueBuilder {
 
                 JField constant = new JField(new CConst("", "", () -> type, () -> value, null), helper, 0);
 
-                writer.formatln("new %s<%s,%s>()",
+                writer.format("new %s<%s,%s>()",
                                 constant.builderInstanceType(),
                                 helper.getFieldType(keyDesc),
                                 helper.getFieldType(itemDesc))
@@ -138,11 +138,12 @@ public class ValueBuilder {
                 Map<Object, Object> map = (Map<Object, Object>) value;
                 for (Map.Entry<Object,Object> entry : map.entrySet()) {
                     writer.appendln(".put(")
-                          .begin();
+                          .begin("     ");
 
                     appendTypedValue(entry.getKey(), keyDesc);
 
-                    writer.appendln(", ");
+                    writer.append(",")
+                          .appendln();
 
                     appendTypedValue(entry.getValue(), itemDesc);
 
@@ -161,14 +162,14 @@ public class ValueBuilder {
 
                 JField constant = new JField(new CConst("", "", () -> type, () -> value, null), helper, 0);
 
-                writer.formatln("new %s<%s>()", constant.builderInstanceType(), helper.getFieldType(itemDesc))
+                writer.format("new %s<%s>()", constant.builderInstanceType(), helper.getFieldType(itemDesc))
                       .begin();
 
                 @SuppressWarnings("unchecked")
                 Collection<Object> items = (Collection<Object>) value;
                 for (Object item : items) {
                     writer.appendln(".add(")
-                          .begin();
+                          .begin("     ");
 
                     appendTypedValue(item, itemDesc);
 

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/ValueBuilder.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/utils/ValueBuilder.java
@@ -2,8 +2,11 @@ package net.morimekta.providence.generator.format.java.utils;
 
 import net.morimekta.providence.PEnumValue;
 import net.morimekta.providence.PMessage;
+import net.morimekta.providence.descriptor.PContainer;
 import net.morimekta.providence.descriptor.PDescriptor;
+import net.morimekta.providence.descriptor.PMap;
 import net.morimekta.providence.generator.GeneratorException;
+import net.morimekta.providence.reflect.contained.CConst;
 import net.morimekta.providence.reflect.contained.CField;
 import net.morimekta.providence.reflect.contained.CStructDescriptor;
 import net.morimekta.util.Binary;
@@ -11,7 +14,9 @@ import net.morimekta.util.io.IndentedPrintWriter;
 import net.morimekta.util.json.JsonException;
 import net.morimekta.util.json.JsonWriter;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Stein Eldar Johnsen
@@ -116,11 +121,67 @@ public class ValueBuilder {
                       .end();
                 break;
             }
-            case MAP:
+            case MAP: {
+                PMap<?,?> lDesc = (PMap<?,?>) type;
+                PDescriptor keyDesc = lDesc.keyDescriptor();
+                PDescriptor itemDesc = lDesc.itemDescriptor();
+
+                JField constant = new JField(new CConst("", "", () -> type, () -> value, null), helper, 0);
+
+                writer.formatln("new %s<%s,%s>()",
+                                constant.builderInstanceType(),
+                                helper.getFieldType(keyDesc),
+                                helper.getFieldType(itemDesc))
+                      .begin("        ");
+
+                @SuppressWarnings("unchecked")
+                Map<Object, Object> map = (Map<Object, Object>) value;
+                for (Map.Entry<Object,Object> entry : map.entrySet()) {
+                    writer.appendln(".put(")
+                          .begin();
+
+                    appendTypedValue(entry.getKey(), keyDesc);
+
+                    writer.appendln(", ");
+
+                    appendTypedValue(entry.getValue(), itemDesc);
+
+                    writer.end()
+                          .append(")");
+                }
+
+                writer.formatln(".build()")
+                      .end();
+                break;
+            }
             case LIST:
-            case SET:
-                // writer.write("null");
-                throw new GeneratorException("Collections cannot have default value.");
+            case SET: {
+                PContainer<?> lDesc = (PContainer<?>) type;
+                PDescriptor itemDesc = lDesc.itemDescriptor();
+
+                JField constant = new JField(new CConst("", "", () -> type, () -> value, null), helper, 0);
+
+                writer.formatln("new %s<%s>()", constant.builderInstanceType(), helper.getFieldType(itemDesc))
+                      .begin("        ");
+
+                @SuppressWarnings("unchecked")
+                Collection<Object> items = (Collection<Object>) value;
+                for (Object item : items) {
+                    writer.appendln(".add(")
+                          .begin();
+
+                    appendTypedValue(item, itemDesc);
+
+                    writer.end()
+                          .append(")");
+                }
+
+                writer.formatln(".build()")
+                      .end();
+                break;
+            }
+            default:
+                throw new GeneratorException("Unhandled value type: " + type.getType());
         }
     }
 }

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CEnumValue.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CEnumValue.java
@@ -114,8 +114,8 @@ public class CEnumValue implements PEnumValue<CEnumValue>, CAnnotatedDescriptor 
         }
         CEnumValue other = (CEnumValue) o;
         return other.descriptor()
-                    .getQualifiedName(null)
-                    .equals(type.getQualifiedName(null)) &&
+                    .getQualifiedName()
+                    .equals(type.getQualifiedName()) &&
                other.getName()
                     .equals(name) &&
                other.getValue() == value;
@@ -124,7 +124,7 @@ public class CEnumValue implements PEnumValue<CEnumValue>, CAnnotatedDescriptor 
     @Override
     public int hashCode() {
         return Objects.hash(CEnumValue.class,
-                            descriptor().getQualifiedName(null),
+                            descriptor().getQualifiedName(),
                             name, value);
     }
 

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CException.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CException.java
@@ -130,9 +130,9 @@ public class CException extends Exception implements PMessage<CException, CField
 
         CException other = (CException) o;
         PStructDescriptor<?, ?> type = other.descriptor();
-        if (!descriptor().getQualifiedName(null)
-                         .equals(type.getQualifiedName(null)) || !descriptor().getVariant()
-                                                                              .equals(type.getVariant())) {
+        if (!descriptor().getQualifiedName()
+                         .equals(type.getQualifiedName()) || !descriptor().getVariant()
+                                                                          .equals(type.getVariant())) {
             return false;
         }
 
@@ -165,7 +165,7 @@ public class CException extends Exception implements PMessage<CException, CField
 
     @Override
     public String toString() {
-        return descriptor().getQualifiedName(null) + asString();
+        return descriptor().getQualifiedName() + asString();
     }
 
     @Override
@@ -263,7 +263,7 @@ public class CException extends Exception implements PMessage<CException, CField
                 throw new IllegalStateException(
                         "Missing required fields " +
                         String.join(",", missing) +
-                        " in message " + descriptor().getQualifiedName(null));
+                        " in message " + descriptor().getQualifiedName());
             }
         }
 

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CField.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CField.java
@@ -36,13 +36,13 @@ import java.util.Set;
  * @since 25.08.15
  */
 public class CField implements PField, CAnnotatedDescriptor {
-    private final String                 comment;
-    private final int                    key;
-    private final PRequirement           requirement;
+    private final String              comment;
+    private final int                 key;
+    private final PRequirement        requirement;
     private final PDescriptorProvider typeProvider;
-    private final String                 name;
+    private final String              name;
     private final PValueProvider      defaultValue;
-    private final Map<String, String>    annotations;
+    private final Map<String, String> annotations;
 
     public CField(String comment,
                   int key,
@@ -98,7 +98,11 @@ public class CField implements PField, CAnnotatedDescriptor {
 
     @Override
     public Object getDefaultValue() {
-        return hasDefaultValue() ? defaultValue.get() : null;
+        try {
+            return hasDefaultValue() ? defaultValue.get() : null;
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to parse default value " + getName(), e);
+        }
     }
 
     @Override
@@ -174,13 +178,7 @@ public class CField implements PField, CAnnotatedDescriptor {
      * @return If the two types are the same.
      */
     private static boolean equalsQualifiedName(PDescriptor a, PDescriptor b) {
-        if ((a == null) != (b == null)) {
-            return false;
-        }
-        if (a == null) {
-            return true;
-        }
-        return a.getQualifiedName(null)
-                .equals(b.getQualifiedName(null));
+        return (a != null) && (b != null) && (a.getQualifiedName(null)
+                                               .equals(b.getQualifiedName(null)));
     }
 }

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CField.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CField.java
@@ -141,7 +141,7 @@ public class CField implements PField, CAnnotatedDescriptor {
             builder.append(requirement.label)
                    .append(" ");
         }
-        builder.append(getDescriptor().getQualifiedName(null))
+        builder.append(getDescriptor().getQualifiedName())
                .append(" ")
                .append(name)
                .append("}");
@@ -178,7 +178,7 @@ public class CField implements PField, CAnnotatedDescriptor {
      * @return If the two types are the same.
      */
     private static boolean equalsQualifiedName(PDescriptor a, PDescriptor b) {
-        return (a != null) && (b != null) && (a.getQualifiedName(null)
-                                               .equals(b.getQualifiedName(null)));
+        return (a != null) && (b != null) && (a.getQualifiedName()
+                                               .equals(b.getQualifiedName()));
     }
 }

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CMessage.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CMessage.java
@@ -126,9 +126,9 @@ public abstract class CMessage<Message extends PMessage<Message, Field>, Field e
 
         CMessage other = (CMessage) o;
         PStructDescriptor<?, ?> type = other.descriptor();
-        if (!descriptor().getQualifiedName(null)
-                         .equals(type.getQualifiedName(null)) || !descriptor().getVariant()
-                                                                              .equals(type.getVariant())) {
+        if (!descriptor().getQualifiedName()
+                         .equals(type.getQualifiedName()) || !descriptor().getVariant()
+                                                                          .equals(type.getVariant())) {
             return false;
         }
 
@@ -161,7 +161,7 @@ public abstract class CMessage<Message extends PMessage<Message, Field>, Field e
 
     @Override
     public String toString() {
-        return descriptor().getQualifiedName(null) + asString();
+        return descriptor().getQualifiedName() + asString();
     }
 
     @Override
@@ -225,9 +225,9 @@ public abstract class CMessage<Message extends PMessage<Message, Field>, Field e
     private static <T extends PMessage<T, F>, F extends PField> int compareMessages(T m1, T m2) {
         int c = 0;
         c = m1.descriptor()
-              .getQualifiedName(null)
+              .getQualifiedName()
               .compareTo(m2.descriptor()
-                           .getQualifiedName(null));
+                           .getQualifiedName());
         if (c != 0) {
             return c;
         }

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CMessageDescriptor.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CMessageDescriptor.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package net.morimekta.providence.reflect.contained;
+
+import net.morimekta.providence.descriptor.PDescriptor;
+import net.morimekta.providence.descriptor.PStructDescriptor;
+
+/**
+ * See the struct descriptor of {@link PStructDescriptor}. It is avoided in this case in
+ * order to be able to have subclasses of PStructDescriptor and PUnionDescriptor to
+ * implement an interface that alreadt have the {@link #getFields()} methods with the
+ * {@link CField} contained field implementation.
+ */
+public interface CMessageDescriptor
+        extends CAnnotatedDescriptor, PDescriptor {
+    // From PMessageDescriptor
+    CField[] getFields();
+
+    CField getField(String name);
+
+    CField getField(int key);
+}

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CStruct.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CStruct.java
@@ -164,7 +164,7 @@ public class CStruct extends CMessage<CStruct,CField> {
                 throw new IllegalStateException(
                         "Missing required fields " +
                         String.join(",", missing) +
-                        " in message " + descriptor().getQualifiedName(null));
+                        " in message " + descriptor().getQualifiedName());
             }
         }
 

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CStructDescriptor.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CStructDescriptor.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * @author Stein Eldar Johnsen
  * @since 07.09.15
  */
-public class CStructDescriptor extends PStructDescriptor<CStruct, CField> implements CAnnotatedDescriptor {
+public class CStructDescriptor extends PStructDescriptor<CStruct, CField> implements CMessageDescriptor {
     public static final int     MAX_COMPACT_FIELDS = 10;
 
     private final String               comment;

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CUnion.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CUnion.java
@@ -171,7 +171,7 @@ public class CUnion extends CMessage<CUnion,CField> implements PUnion<CUnion,CFi
         public void validate() {
             if (!isValid()) {
                 throw new IllegalStateException("No union field set in " +
-                                                descriptor().getQualifiedName(null));
+                                                descriptor().getQualifiedName());
             }
         }
 

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CUnionDescriptor.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/contained/CUnionDescriptor.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * @author Stein Eldar Johnsen
  * @since 07.09.15
  */
-public class CUnionDescriptor extends PUnionDescriptor<CUnion, CField> implements CAnnotatedDescriptor {
+public class CUnionDescriptor extends PUnionDescriptor<CUnion, CField> implements CMessageDescriptor {
     private final CField[]             fields;
     private final Map<Integer, CField> fieldIdMap;
     private final Map<String, CField>  fieldNameMap;

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/ThriftProgramParser.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/ThriftProgramParser.java
@@ -355,7 +355,7 @@ public class ThriftProgramParser implements ProgramParser {
                         tokenizer.expectSymbol("", Token.kFieldValueSep);
                         Token value = tokenizer.expectStringLiteral("annotation value");
 
-                        field.putInAnnotations(name, value.decodeLiteral());
+                        field.putInAnnotations(name, value.decodeStringLiteral());
 
                         sep = tokenizer.expectSymbol("annotation sep", Token.kParamsEnd, Token.kLineSep1, Token.kLineSep2);
                     }
@@ -415,7 +415,7 @@ public class ThriftProgramParser implements ProgramParser {
                             tokenizer.expectSymbol("", Token.kFieldValueSep);
                             Token value = tokenizer.expectStringLiteral("exception annotation value");
 
-                            field.putInAnnotations(name, value.decodeLiteral());
+                            field.putInAnnotations(name, value.decodeStringLiteral());
 
                             sep = tokenizer.expectSymbol("exception annotation sep",
                                                          Token.kParamsEnd,
@@ -444,7 +444,7 @@ public class ThriftProgramParser implements ProgramParser {
                     tokenizer.expectSymbol("", Token.kFieldValueSep);
                     Token value = tokenizer.expectStringLiteral("annotation value");
 
-                    method.putInAnnotations(name, value.decodeLiteral());
+                    method.putInAnnotations(name, value.decodeStringLiteral());
 
                     sep = tokenizer.expectSymbol("annotation sep", Token.kParamsEnd, Token.kLineSep1, Token.kLineSep2);
                 }
@@ -470,7 +470,7 @@ public class ThriftProgramParser implements ProgramParser {
                     tokenizer.expectSymbol("", Token.kFieldValueSep);
                     Token value = tokenizer.expectStringLiteral("annotation value");
 
-                    service.putInAnnotations(name, value.decodeLiteral());
+                    service.putInAnnotations(name, value.decodeStringLiteral());
 
                     sep = tokenizer.expectSymbol("annotation sep", Token.kParamsEnd, Token.kLineSep1, Token.kLineSep2);
                 }
@@ -580,7 +580,7 @@ public class ThriftProgramParser implements ProgramParser {
                             tokenizer.expectSymbol("", Token.kFieldValueSep);
                             Token val = tokenizer.expectStringLiteral("annotation value");
 
-                            evb.putInAnnotations(name, val.decodeLiteral());
+                            evb.putInAnnotations(name, val.decodeStringLiteral());
 
                             sep2 = tokenizer.expectSymbol("annotation sep", Token.kParamsEnd, Token.kLineSep1, Token.kLineSep2);
                         }
@@ -611,7 +611,7 @@ public class ThriftProgramParser implements ProgramParser {
                 tokenizer.expectSymbol("", Token.kFieldValueSep);
                 Token val = tokenizer.expectStringLiteral("annotation value");
 
-                etb.putInAnnotations(name, val.decodeLiteral());
+                etb.putInAnnotations(name, val.decodeStringLiteral());
 
                 sep = tokenizer.expectSymbol("annotation sep", Token.kParamsEnd, Token.kLineSep1, Token.kLineSep2);
             }
@@ -740,7 +740,7 @@ public class ThriftProgramParser implements ProgramParser {
                     tokenizer.expectSymbol("", Token.kFieldValueSep);
                     Token val = tokenizer.expectStringLiteral("annotation value");
 
-                    field.putInAnnotations(aName, val.decodeLiteral());
+                    field.putInAnnotations(aName, val.decodeStringLiteral());
 
                     sep = tokenizer.expectSymbol("annotation sep", Token.kParamsEnd, Token.kLineSep1, Token.kLineSep2);
                 }
@@ -764,7 +764,7 @@ public class ThriftProgramParser implements ProgramParser {
                 tokenizer.expectSymbol("", Token.kFieldValueSep);
                 Token val = tokenizer.expectStringLiteral("annotation value");
 
-                struct.putInAnnotations(name, val.decodeLiteral());
+                struct.putInAnnotations(name, val.decodeStringLiteral());
 
                 sep = tokenizer.expectSymbol("annotation sep", Token.kParamsEnd, Token.kLineSep1, Token.kLineSep2);
             }

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/internal/ConstParser.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/internal/ConstParser.java
@@ -20,9 +20,11 @@
 package net.morimekta.providence.reflect.parser.internal;
 
 import net.morimekta.providence.PEnumBuilder;
+import net.morimekta.providence.PEnumValue;
 import net.morimekta.providence.PMessage;
 import net.morimekta.providence.PMessageBuilder;
 import net.morimekta.providence.PType;
+import net.morimekta.providence.descriptor.PDeclaredDescriptor;
 import net.morimekta.providence.descriptor.PDescriptor;
 import net.morimekta.providence.descriptor.PEnumDescriptor;
 import net.morimekta.providence.descriptor.PField;
@@ -31,6 +33,7 @@ import net.morimekta.providence.descriptor.PMap;
 import net.morimekta.providence.descriptor.PSet;
 import net.morimekta.providence.descriptor.PStructDescriptor;
 import net.morimekta.providence.reflect.parser.ParseException;
+import net.morimekta.providence.util.TypeRegistry;
 import net.morimekta.util.Base64;
 import net.morimekta.util.Strings;
 import net.morimekta.util.json.JsonException;
@@ -56,16 +59,20 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
  * @since 25.08.15
  */
 public class ConstParser {
-    public ConstParser() {}
+    private final TypeRegistry registry;
+    private final String program;
+
+    public ConstParser(TypeRegistry registry, String program) {
+        this.registry = registry;
+        this.program = program;
+    }
 
     public Object parse(InputStream inputStream, PDescriptor type) throws ParseException {
         try {
-            JsonTokenizer tokenizer = new JsonTokenizer(inputStream);
+            Tokenizer tokenizer = new Tokenizer(inputStream);
             return parseTypedValue(tokenizer.expect("const value"), tokenizer, type);
-        } catch (JsonException e) {
-            throw new ParseException(e, "Unable to parse JSON: " + e.getMessage());
         } catch (IOException e) {
-            throw new ParseException(e, "Unable to read JSON data from input: " + e.getMessage());
+            throw new ParseException(e, "Unable to read const data from input: " + e.getMessage());
         }
     }
 
@@ -79,9 +86,8 @@ public class ConstParser {
      * @return The parsed message.
      */
     private <Message extends PMessage<Message, Field>, Field extends PField>
-    Message parseMessage(JsonTokenizer tokenizer,
-                         PStructDescriptor<Message, Field> type)
-            throws IOException, JsonException {
+    Message parseMessage(Tokenizer tokenizer,
+                         PStructDescriptor<Message, Field> type) throws ParseException, IOException {
         PMessageBuilder<Message, Field> builder = type.builder();
 
         if (tokenizer.peek("checking for empty").isSymbol(JsonToken.kMapEnd)) {
@@ -91,11 +97,10 @@ public class ConstParser {
 
         char sep = JsonToken.kMapStart;
         while (sep != JsonToken.kMapEnd) {
-            JsonToken token = tokenizer.expectString("message field name");
-            Field field = type.getField(token.substring(1, -1)
-                                             .asString());
+            Token token = tokenizer.expectStringLiteral("message field name");
+            Field field = type.getField(token.decodeStringLiteral());
             if (field == null) {
-                throw new JsonException("Not a valid field name: " + token.substring(1, -1));
+                throw new ParseException(tokenizer, token, "Not a valid field name: " + token.decodeStringLiteral());
             }
             tokenizer.expectSymbol("parsing message key-value sep", JsonToken.kKeyValSep);
 
@@ -108,52 +113,52 @@ public class ConstParser {
         return builder.build();
     }
 
-    private Object parseTypedValue(JsonToken token, JsonTokenizer tokenizer, PDescriptor valueType)
-            throws IOException, JsonException {
+    private Object parseTypedValue(Token token, Tokenizer tokenizer, PDescriptor valueType)
+            throws ParseException, IOException {
         switch (valueType.getType()) {
             case BOOL:
-                if (token.isBoolean()) {
-                    return token.booleanValue();
+                if (token.isIdentifier()) {
+                    return Boolean.parseBoolean(token.asString());
                 } else if (token.isInteger()) {
-                    return token.longValue() != 0;
+                    return token.parseInteger() != 0L;
                 }
-                throw new JsonException("Not boolean value for bool: " + token.asString(), tokenizer, token);
+                throw new ParseException(tokenizer, token, "Not boolean value for bool: " + token.asString());
             case BYTE:
                 if (token.isInteger()) {
-                    return token.byteValue();
+                    return (byte) token.parseInteger();
                 }
-                throw new JsonException(token.asString() + " is not a valid byte value.", tokenizer, token);
+                return (byte) findEnumValue(token.asString(), token, tokenizer, "byte");
             case I16:
                 if (token.isInteger()) {
-                    return token.shortValue();
+                    return (short) token.parseInteger();
                 }
-                throw new JsonException(token.asString() + " is not a valid short value.", tokenizer, token);
+                return (short) findEnumValue(token.asString(), token, tokenizer, "i16");
             case I32:
                 if (token.isInteger()) {
-                    return token.intValue();
+                    return (int) token.parseInteger();
                 }
-                throw new JsonException(token.asString() + " is not a valid int value.", tokenizer, token);
+                return findEnumValue(token.asString(), token, tokenizer, "i32");
             case I64:
                 if (token.isInteger()) {
-                    return token.longValue();
+                    return token.parseInteger();
                 }
-                throw new JsonException(token.asString() + " is not a valid long value.", tokenizer, token);
+                return (long) findEnumValue(token.asString(), token, tokenizer, "i64");
             case DOUBLE:
                 if (token.isInteger() || token.isDouble()) {
-                    return token.doubleValue();
+                    return token.parseDouble();
                 }
-                throw new JsonException(token.asString() + " is not a valid double value.", tokenizer, token);
+                throw new ParseException(tokenizer, token, token.asString() + " is not a valid double value.");
             case STRING:
-                if (token.isLiteral()) {
-                    return token.decodeJsonLiteral();
+                if (token.isStringLiteral()) {
+                    return token.decodeStringLiteral();
                 }
-                throw new JsonException("Not a valid string value.", tokenizer, token);
+                throw new ParseException(tokenizer, token, "Not a valid string value.");
             case BINARY:
-                if (token.isLiteral()) {
+                if (token.isStringLiteral()) {
                     return parseBinary(token.substring(1, -1)
                                             .asString());
                 }
-                throw new JsonException("Not a valid binary value.", tokenizer, token);
+                throw new ParseException(tokenizer, token, "Not a valid binary value.");
             case ENUM: {
                 PEnumBuilder<?> eb = ((PEnumDescriptor<?>) valueType).builder();
                 String name = token.asString();
@@ -164,9 +169,7 @@ public class ConstParser {
                 Object ev = eb.setByName(name)
                               .build();
                 if (ev == null) {
-                    throw new JsonException("No such " + valueType.getQualifiedName(null) + " enum value.",
-                                            tokenizer,
-                                            token);
+                    throw new ParseException(tokenizer, token, "No such " + valueType.getQualifiedName(null) + " enum value.");
                 }
                 return ev;
             }
@@ -174,7 +177,7 @@ public class ConstParser {
                 if (token.isSymbol(JsonToken.kMapStart)) {
                     return parseMessage(tokenizer, (PStructDescriptor<?, ?>) valueType);
                 }
-                throw new JsonException("Not a valid message start.", tokenizer, token);
+                throw new ParseException(tokenizer, token, "Not a valid message start.");
             }
             case LIST: {
                 PDescriptor itemType = ((PList<?>) valueType).itemDescriptor();
@@ -182,13 +185,22 @@ public class ConstParser {
 
                 if (tokenizer.peek("checking for empty list")
                              .isSymbol(JsonToken.kListEnd)) {
+                    tokenizer.next();
                     return list;
                 }
 
-                char sep = JsonToken.kListStart;
-                while (sep != JsonToken.kListEnd) {
+                while (true) {
                     list.add(parseTypedValue(tokenizer.expect("list item value"), tokenizer, itemType));
-                    sep = tokenizer.expectSymbol("parsing list item separator", JsonToken.kListEnd, JsonToken.kListSep);
+
+                    Token sep = tokenizer.peek("optional item sep");
+                    if (sep.isSymbol(Token.kLineSep1) || sep.isSymbol(Token.kLineSep2)) {
+                        tokenizer.next();
+                        sep = tokenizer.peek("check for set end");
+                    }
+                    if (sep.isSymbol(Token.kListEnd)) {
+                        tokenizer.next();
+                        break;
+                    }
                 }
 
                 return list;
@@ -199,13 +211,22 @@ public class ConstParser {
 
                 if (tokenizer.peek("checking for empty list")
                              .isSymbol(JsonToken.kListEnd)) {
+                    tokenizer.next();
                     return set;
                 }
 
-                char sep = JsonToken.kListStart;
-                while (sep != JsonToken.kListEnd) {
+                while (true) {
                     set.add(parseTypedValue(tokenizer.expect("set item value"), tokenizer, itemType));
-                    sep = tokenizer.expectSymbol("parsing set item separator", JsonToken.kListEnd, JsonToken.kListSep);
+
+                    Token sep = tokenizer.peek("optional item sep");
+                    if (sep.isSymbol(Token.kLineSep1) || sep.isSymbol(Token.kLineSep2)) {
+                        tokenizer.next();
+                        sep = tokenizer.peek("check for set end");
+                    }
+                    if (sep.isSymbol(Token.kListEnd)) {
+                        tokenizer.next();
+                        break;
+                    }
                 }
                 return set;
             }
@@ -217,25 +238,34 @@ public class ConstParser {
 
                 if (tokenizer.peek("checking for empty map")
                              .isSymbol(JsonToken.kMapEnd)) {
+                    tokenizer.next();
                     return map;
                 }
 
-                char sep = JsonToken.kMapStart;
-                while (sep != JsonToken.kMapEnd) {
+                while (true) {
                     Object key;
-                    if (token.isLiteral()) {
-                        key = parsePrimitiveKey(token.decodeJsonLiteral(), keyType);
+                    token = tokenizer.expect("map key");
+                    if (token.isStringLiteral()) {
+                        key = parsePrimitiveKey(token.decodeStringLiteral(), token, tokenizer, keyType);
                     } else {
                         if (keyType.getType().equals(PType.STRING) ||
                             keyType.getType().equals(PType.BINARY)) {
-                            throw new JsonException("Expected string literal for string key", tokenizer, token);
+                            throw new ParseException(tokenizer, token, "Expected string literal for string key");
                         }
-                        key = parsePrimitiveKey(token.asString(), keyType);
+                        key = parsePrimitiveKey(token.asString(), token, tokenizer, keyType);
                     }
-                    tokenizer.expectSymbol("parsing map (kv)", JsonToken.kKeyValSep);
-                    map.put(key, parseTypedValue(tokenizer.expect("parsing map value."), tokenizer, itemType));
+                    tokenizer.expectSymbol("map key-value separator", JsonToken.kKeyValSep);
+                    map.put(key, parseTypedValue(tokenizer.expect("map value"), tokenizer, itemType));
 
-                    sep = tokenizer.expectSymbol("parsing set item separator", JsonToken.kMapEnd, JsonToken.kListSep);
+                    Token sep = tokenizer.peek("optional item sep");
+                    if (sep.isSymbol(Token.kLineSep1) || sep.isSymbol(Token.kLineSep2)) {
+                        tokenizer.next();
+                        sep = tokenizer.peek("check for map end");
+                    }
+                    if (sep.isSymbol(Token.kMessageEnd)) {
+                        tokenizer.next();
+                        break;
+                    }
                 }
 
                 return map;
@@ -245,7 +275,8 @@ public class ConstParser {
         }
     }
 
-    private Object parsePrimitiveKey(String key, PDescriptor keyType) throws IOException {
+    private Object parsePrimitiveKey(String key, Token token, Tokenizer tokenizer, PDescriptor keyType)
+            throws ParseException {
         switch (keyType.getType()) {
             case ENUM:
                 PEnumBuilder<?> eb = ((PEnumDescriptor<?>) keyType).builder();
@@ -253,10 +284,12 @@ public class ConstParser {
                     return eb.setByValue(Integer.parseInt(key))
                              .build();
                 } else {
-                    // Check for qualified name ( e.g. EnumName.VALUE ).
-                    if (key.startsWith(keyType.getName())) {
-                        key = key.substring(keyType.getName()
-                                                   .length() + 1);
+                    if (key.startsWith(keyType.getProgramName() + "." + keyType.getName() + ".")) {
+                        // Check for qualified type prefixed identifier ( e.g. program.EnumName.VALUE ).
+                        key = key.substring(keyType.getProgramName().length() + keyType.getName().length() + 2);
+                    } else if (key.startsWith(keyType.getName() + ".")) {
+                        // Check for type prefixed identifier ( e.g. EnumName.VALUE ).
+                        key = key.substring(keyType.getName().length() + 1);
                     }
                     return eb.setByName(key)
                              .build();
@@ -264,30 +297,74 @@ public class ConstParser {
             case BOOL:
                 return Boolean.parseBoolean(key);
             case BYTE:
-                return Byte.parseByte(key);
+                if (Strings.isInteger(key)) {
+                    return Byte.parseByte(key);
+                } else {
+                    return (byte) findEnumValue(key, token, tokenizer, "byte");
+                }
             case I16:
-                return Short.parseShort(key);
+                if (Strings.isInteger(key)) {
+                    return Short.parseShort(key);
+                } else {
+                    return (short) findEnumValue(key, token, tokenizer, "i16");
+                }
             case I32:
-                return Integer.parseInt(key);
+                if (Strings.isInteger(key)) {
+                    return Integer.parseInt(key);
+                } else {
+                    return findEnumValue(key, token, tokenizer, "i32");
+                }
             case I64:
-                return Long.parseLong(key);
-            case DOUBLE:
+                if (Strings.isInteger(key)) {
+                    return Long.parseLong(key);
+                } else {
+                    return (long) findEnumValue(key, token, tokenizer, "i64");
+                }
+            case DOUBLE: {
                 try {
                     ByteArrayInputStream bais = new ByteArrayInputStream(key.getBytes(US_ASCII));
                     JsonTokenizer tokener = new JsonTokenizer(bais);
-                    JsonToken token = tokener.expect("parsing double value");
-                    return token.doubleValue();
-                } catch (JsonException e) {
-                    throw new IllegalArgumentException("Unable to parse double from key \"" +
-                                                       key + "\"", e);
+                    JsonToken jt = tokener.expect("parsing double value");
+                    return jt.doubleValue();
+                } catch (IOException | JsonException e) {
+                    throw new ParseException(e, "Unable to parse double value");
                 }
+            }
             case STRING:
                 return key;
             case BINARY:
                 return parseBinary(key);
             default:
-                throw new IllegalArgumentException("Illegal key type: " + keyType.getType());
+                throw new ParseException("Illegal key type: " + keyType.getType());
         }
+    }
+
+    private int findEnumValue(String identifier, Token token, Tokenizer tokenizer, String expectedType)
+            throws ParseException {
+        String[] parts = identifier.split("[.]");
+        String typeName;
+        String valueName;
+        if (parts.length == 3) {
+            typeName = parts[0] + "." + parts[1];
+            valueName = parts[2];
+        } else if (parts.length == 2) {
+            typeName = parts[0];
+            valueName = parts[1];
+        } else {
+            throw new ParseException(tokenizer, token, identifier + " is not a valid " + expectedType + " value.");
+        }
+
+        @SuppressWarnings("unchecked")
+        PDeclaredDescriptor descriptor = registry.getDeclaredType(typeName, program);
+        if (descriptor != null && descriptor instanceof PEnumDescriptor) {
+            PEnumDescriptor desc = (PEnumDescriptor) descriptor;
+            PEnumValue value = desc.getValueByName(valueName);
+            if (value != null) {
+                return value.getValue();
+            }
+        }
+
+        throw new ParseException(tokenizer, token, identifier + " is not a valid " + expectedType + " value.");
     }
 
     /**
@@ -296,7 +373,7 @@ public class ConstParser {
      * @param value The string to decode.
      * @return The decoded byte array.
      */
-    private byte[] parseBinary(String value) throws IOException {
+    private byte[] parseBinary(String value) {
         return Base64.decode(value);
     }
 }

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/internal/ConstParser.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/internal/ConstParser.java
@@ -180,7 +180,7 @@ public class ConstParser {
                 Object ev = eb.setByName(name)
                               .build();
                 if (ev == null) {
-                    throw new ParseException(tokenizer, token, "No such " + valueType.getQualifiedName(null) + " enum value.");
+                    throw new ParseException(tokenizer, token, "No such " + valueType.getQualifiedName() + " enum value.");
                 }
                 return ev;
             }
@@ -282,7 +282,7 @@ public class ConstParser {
                 return map;
             }
             default:
-                throw new IllegalArgumentException("Unhandled item type " + valueType.getQualifiedName(null));
+                throw new IllegalArgumentException("Unhandled item type " + valueType.getQualifiedName());
         }
     }
 

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/internal/Token.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/parser/internal/Token.java
@@ -101,6 +101,7 @@ public class Token extends Slice {
     private static final Pattern RE_QUALIFIED_IDENTIFIER = Pattern.compile(
             "([_a-zA-Z][_a-zA-Z0-9]*[.])*[_a-zA-Z][_a-zA-Z0-9]*");
     private static final Pattern RE_INTEGER              = Pattern.compile("-?(0|[1-9][0-9]*|0[0-7]+|0x[0-9a-fA-F]+)");
+    private static final Pattern RE_DOUBLE               = Pattern.compile("-?((0|[1-9][0-9]*)[.]|([0-9]*[.][0-9][0-9]*))([eE][-+]?[0-9][0-9]*)?");
 
     private final int lineNo;
     private final int linePos;
@@ -149,8 +150,8 @@ public class Token extends Slice {
 
     public boolean isStringLiteral() {
         return (length() > 1 &&
-                charAt(0) == '\"' &&
-                charAt(-1) == '\"');
+                ((charAt(0) == '\"' && charAt(-1) == '\"') ||
+                 (charAt(0) == '\'' && charAt(-1) == '\'')));
     }
 
     public boolean isIdentifier() {
@@ -168,12 +169,17 @@ public class Token extends Slice {
                          .matches();
     }
 
+    public boolean isDouble() {
+        return RE_DOUBLE.matcher(asString())
+                        .matches();
+    }
+
     /**
      * Get the whole slice as a string.
      *
      * @return Slice decoded as UTF_8 string.
      */
-    public String decodeLiteral() {
+    public String decodeStringLiteral() {
         // This decodes the string from UTF_8 bytes.
         String tmp = substring(1, -1).asString();
         final int l = tmp.length();

--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/util/ConstProvider.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/util/ConstProvider.java
@@ -34,35 +34,35 @@ import java.util.Collections;
  * @since 07.09.15
  */
 public class ConstProvider implements PValueProvider<Object> {
-    private final ProgramRegistry mRegistry;
-    private final String          mTypeName;
-    private final String          mPackageContext;
-    private final String          mDefaultValue;
+    private final ProgramRegistry registry;
+    private final String          typeName;
+    private final String          programContext;
+    private final String          defaultValue;
 
-    private Object mParsedValue;
+    private Object parsedValue;
 
-    public ConstProvider(ProgramRegistry registry, String typeName, String packageContext, String defaultValue) {
-        mRegistry = registry;
-        mTypeName = typeName;
-        mPackageContext = packageContext;
-        mDefaultValue = defaultValue;
-        mParsedValue = null;
+    public ConstProvider(ProgramRegistry registry, String typeName, String programContext, String defaultValue) {
+        this.registry = registry;
+        this.typeName = typeName;
+        this.programContext = programContext;
+        this.defaultValue = defaultValue;
+        this.parsedValue = null;
     }
 
     @Override
     public Object get() {
-        if (mParsedValue == null) {
-            ConstParser parser = new ConstParser();
+        if (parsedValue == null) {
+            ConstParser parser = new ConstParser(registry, programContext);
             @SuppressWarnings("unchecked")
-            PDescriptor type = mRegistry.getProvider(mTypeName, mPackageContext, Collections.EMPTY_MAP)
-                                        .descriptor();
-            try (ByteArrayInputStream in = new ByteArrayInputStream(mDefaultValue.getBytes(StandardCharsets.UTF_8))) {
-                mParsedValue = parser.parse(in, type);
+            PDescriptor type = registry.getProvider(typeName, programContext, Collections.EMPTY_MAP)
+                                       .descriptor();
+            try (ByteArrayInputStream in = new ByteArrayInputStream(defaultValue.getBytes(StandardCharsets.UTF_8))) {
+                parsedValue = parser.parse(in, type);
             } catch (ParseException | IOException e) {
                 e.printStackTrace();
             }
         }
 
-        return mParsedValue;
+        return parsedValue;
     }
 }

--- a/providence-reflect/src/test/java/net/morimekta/providence/reflect/parser/internal/TokenTest.java
+++ b/providence-reflect/src/test/java/net/morimekta/providence/reflect/parser/internal/TokenTest.java
@@ -1,0 +1,27 @@
+package net.morimekta.providence.reflect.parser.internal;
+
+import net.morimekta.providence.reflect.parser.ParseException;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Testing the token parser.
+ */
+public class TokenTest {
+    @Test
+    public void testIsDouble() throws IOException, ParseException {
+        Tokenizer tokenizer = new Tokenizer(new ByteArrayInputStream("\n\n  3.141692,\n".getBytes(StandardCharsets.UTF_8)));
+        Token token = tokenizer.next();
+
+        assertThat(token.asString(), is(equalTo("3.141692")));
+        assertThat(token.isDouble(), is(true));
+    }
+}

--- a/providence-testing/src/test/providence/calculator/calculator.thrift
+++ b/providence-testing/src/test/providence/calculator/calculator.thrift
@@ -35,6 +35,13 @@ const Operand PI = {
   "number": 3.141592
 };
 
+const map<i32, number.Imaginary> imaginaries = {
+    Operator.IDENTITY: {
+        'v': 3.141592;
+        'i': -2.71828;
+    },
+}
+
 const set<Operator> kComplexOperands = [
     Operator.MULTIPLY,
     Operator.DIVIDE

--- a/providence-thrift/src/main/java/net/morimekta/providence/thrift/TProtocolSerializer.java
+++ b/providence-thrift/src/main/java/net/morimekta/providence/thrift/TProtocolSerializer.java
@@ -198,7 +198,7 @@ class TProtocolSerializer extends Serializer {
         PStructDescriptor<?, ?> type = message.descriptor();
 
         protocol.writeStructBegin(new TStruct(message.descriptor()
-                                                     .getQualifiedName(null)));
+                                                     .getQualifiedName()));
 
         for (PField field : type.getFields()) {
             if (!message.has(field.getKey())) {
@@ -234,13 +234,13 @@ class TProtocolSerializer extends Serializer {
             if (f.id != 0) {
                 field = descriptor.getField(f.id);
                 if (field == null) {
-                    throw new SerializerException("No such field " + f.id + " in " + descriptor.getQualifiedName(null));
+                    throw new SerializerException("No such field " + f.id + " in " + descriptor.getQualifiedName());
                 }
             } else {
                 field = descriptor.getField(f.name);
                 if (field == null) {
                     throw new SerializerException(
-                            "No such field " + f.name + " in " + descriptor.getQualifiedName(null));
+                            "No such field " + f.name + " in " + descriptor.getQualifiedName());
                 }
             }
 
@@ -289,7 +289,7 @@ class TProtocolSerializer extends Serializer {
                     eb.setByValue(value);
                     if (!eb.isValid() && readStrict) {
                         throw new SerializerException("Invalid enum value " + value + " for " +
-                                                      et.getQualifiedName(null));
+                                                      et.getQualifiedName());
                     }
                     return eb.build();
                 } else {

--- a/providence-thrift/src/main/java/net/morimekta/providence/thrift/TTupleProtocolSerializer.java
+++ b/providence-thrift/src/main/java/net/morimekta/providence/thrift/TTupleProtocolSerializer.java
@@ -296,7 +296,7 @@ public class TTupleProtocolSerializer extends Serializer {
                 eb.setByValue(value);
                 if (readStrict && !eb.isValid()) {
                     throw new SerializerException("Invalid enum value " + value + " for " +
-                                                  et.getQualifiedName(null));
+                                                  et.getQualifiedName());
                 }
                 return eb.build();
             }


### PR DESCRIPTION
- Properly accept single quite literals ('..').
- Accept using enum values for number references in constants.
- Fix parsing of const maps and lists.
- Allow default values to be containers.
- Properly detect doubles in constants.
- Use thrift tokenizer all over instead of json tokenizer. This requires
  a little more funcitonality to the token class.

In the generator:

- Annotate generator exception on which const was failed to generate.
- Generate collections for the value builder, so that container
  constants can contain containers (and allows maps, lists and sets in
  default values).