### PR TITLE
Support annotating thrift fields with max length for toString()

### DIFF
--- a/providence-reflect/src/main/java/net/morimekta/providence/reflect/util/ThriftAnnotation.java
+++ b/providence-reflect/src/main/java/net/morimekta/providence/reflect/util/ThriftAnnotation.java
@@ -103,6 +103,16 @@ public enum ThriftAnnotation {
      * hazelcast.factory.id = "1"
      */
     JAVA_HAZELCAST_CLASS_ID("hazelcast.class.id"),
+
+    /**
+     * Specify if a field's binary or string inside a struct/union/exception should
+     * limit it's toString length for the given field.
+     * <p>
+     * This is useful if you are forwarding providence models directly to a logger
+     * and is not interested in logging all it's contents.
+     */
+    JAVA_TOSTRING_MAXLENGTH("java.tostring.maxlength"),
+
     ;
 
     public final String tag;

--- a/providence-testing/src/test/java/net/morimekta/providence/gentests/ProvidenceTest.java
+++ b/providence-testing/src/test/java/net/morimekta/providence/gentests/ProvidenceTest.java
@@ -21,13 +21,16 @@
 package net.morimekta.providence.gentests;
 
 import net.morimekta.providence.serializer.BinarySerializer;
+import net.morimekta.test.providence.AnnotationsSutForMaxLength;
 import net.morimekta.test.providence.AutoIdFields;
 import net.morimekta.test.providence.CompactFields;
 import net.morimekta.test.providence.Containers;
 import net.morimekta.test.providence.DefaultValues;
 import net.morimekta.test.providence.EnumNames;
+import net.morimekta.test.providence.ExceptionAnnotationsSutForMaxLength;
 import net.morimekta.test.providence.OptionalFields;
 import net.morimekta.test.providence.RequiredFields;
+import net.morimekta.test.providence.UnionAnnotationsSutForMaxLength;
 import net.morimekta.test.providence.UnionFields;
 import net.morimekta.test.providence.Value;
 import net.morimekta.util.Binary;
@@ -50,6 +53,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -201,6 +205,61 @@ public class ProvidenceTest {
         assertThat(of.hashCode(), is(equalTo(of2.hashCode())));
         assertThat(of.hashCode(), not(equalTo(rf.hashCode())));
         assertThat(uf.hashCode(), not(equalTo(rf.hashCode())));
+    }
+
+    @Test
+    public void testAnnotation_ToString_MaxLength_Struct() {
+        Binary testData = Binary.copy(new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8});
+        AnnotationsSutForMaxLength sut = AnnotationsSutForMaxLength.builder()
+                                                                   .setBinaryValueWithAnnotation(Binary.copy(testData.get()))
+                                                                   .setBinaryValue(Binary.copy(testData.get()))
+                                                                   .setStringValue("123456789")
+                                                                   .setStringValueWithAnnotation("123456789")
+                                                                   .build();
+        assertThat(sut.toString(), is(containsString("binaryValueWithAnnotation:binary(length:9, hashCode:-883926621)")));
+        assertThat(sut.toString(), is(containsString("binaryValue:b64(AAECAwQFBgcI)")));
+        assertThat(sut.toString(), is(containsString("binaryValue:b64(AAECAwQFBgcI)")));
+        assertThat(sut.toString(), is(containsString("stringValueWithAnnotation:string(startsWith:\"12345678\"..., length:9)")));
+        assertThat(sut.toString(), is(containsString("stringValue:\"123456789\"")));
+    }
+
+    @Test
+    public void testAnnotation_ToString_MaxLength_Exception() {
+        Binary testData = Binary.copy(new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8});
+        ExceptionAnnotationsSutForMaxLength sut = ExceptionAnnotationsSutForMaxLength.builder()
+                                                                                     .setBinaryValueWithAnnotation(
+                                                                                             Binary.copy(testData.get()))
+                                                                                     .setBinaryValue(Binary.copy(
+                                                                                             testData.get()))
+                                                                                     .setStringValue("123456789")
+                                                                                     .setStringValueWithAnnotation(
+                                                                                             "123456789")
+                                                                                     .build();
+        assertThat(sut.toString(), is(containsString("binaryValueWithAnnotation:binary(length:9, hashCode:-883926621)")));
+        assertThat(sut.toString(), is(containsString("binaryValue:b64(AAECAwQFBgcI)")));
+        assertThat(sut.toString(), is(containsString("binaryValue:b64(AAECAwQFBgcI)")));
+        assertThat(sut.toString(), is(containsString("stringValueWithAnnotation:string(startsWith:\"12345678\"..., length:9)")));
+        assertThat(sut.toString(), is(containsString("stringValue:\"123456789\"")));
+    }
+
+    @Test
+    public void testAnnotation_ToString_MaxLength_Union() {
+        Binary testData = Binary.copy(new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8});
+        UnionAnnotationsSutForMaxLength sut = UnionAnnotationsSutForMaxLength
+                .withBinaryValueWithAnnotation(Binary.copy(testData.get()));
+        assertThat(sut.toString(), is(containsString("binaryValueWithAnnotation:binary(length:9, hashCode:-883926621)")));
+
+
+        sut = UnionAnnotationsSutForMaxLength.withBinaryValue(Binary.copy(testData.get()));
+        assertThat(sut.toString(), is(containsString("binaryValue:b64(AAECAwQFBgcI)")));
+
+
+        sut = UnionAnnotationsSutForMaxLength.withStringValue("123456789");
+        assertThat(sut.toString(), is(containsString("stringValue:\"123456789\"")));
+
+
+        sut = UnionAnnotationsSutForMaxLength.withStringValueWithAnnotation("123456789");
+        assertThat(sut.toString(), is(containsString("stringValueWithAnnotation:string(startsWith:\"12345678\"..., length:9)")));
     }
 
     @Test

--- a/providence-testing/src/test/providence/providence.thrift
+++ b/providence-testing/src/test/providence/providence.thrift
@@ -198,3 +198,29 @@ struct Containers {
     62: optional map<i8,list<i32>> map_i8_list_i32;
 }
 
+struct AnnotationsSutForMaxLength {
+  1: optional binary binaryValueWithAnnotation
+   (java.tostring.maxlength = "8")
+  2: optional binary binaryValue
+  3: optional string stringValueWithAnnotation
+   (java.tostring.maxlength = "8")
+  4: optional string stringValue
+}
+
+union UnionAnnotationsSutForMaxLength {
+  1: optional binary binaryValueWithAnnotation
+   (java.tostring.maxlength = "8")
+  2: optional binary binaryValue
+  3: optional string stringValueWithAnnotation
+   (java.tostring.maxlength = "8")
+  4: optional string stringValue
+}
+
+exception ExceptionAnnotationsSutForMaxLength {
+  1: optional binary binaryValueWithAnnotation
+   (java.tostring.maxlength = "8")
+  2: optional binary binaryValue
+  3: optional string stringValueWithAnnotation
+   (java.tostring.maxlength = "8")
+  4: optional string stringValue
+}

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -75,6 +75,10 @@ generated code. Currently the recognized annotations are:
 * `java.exception.class` Which exception class to inherit from. This must be the
   full class path of an exception. Note that whether it is an exception is not
   checked in the generator, it is plainly trusted as the exception class.
+* `java.tostring.maxlength` Each field in a message (union, struct, exception) can
+ be annotated with this which limits the given field's output when calling
+  `toString()`. Useful if you are forwarding `PMessage` to a logger and don't want
+   to log large fields. Currently only supports `string` and `binary`.
 * `java.service.methods.throws` Which replaces the declared exceptions with the
   given exception class on the **service interface only**. Also note that:
 


### PR DESCRIPTION
This is useful for using providence models directly in loggers and where we
don't want to log huge binaries or strings.

Currently support fields of type binary or string.