### PR TITLE
Use buffered streams when generating java code

### DIFF
--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/JavaGenerator.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/JavaGenerator.java
@@ -39,6 +39,7 @@ import net.morimekta.providence.reflect.contained.CService;
 import net.morimekta.providence.reflect.util.ProgramTypeRegistry;
 import net.morimekta.util.io.IndentedPrintWriter;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -101,7 +102,7 @@ public class JavaGenerator extends Generator {
 
         if (program.getConstants().size() > 0) {
             String file = helper.getConstantsClassName(program) + ".java";
-            OutputStream out = getFileManager().create(path, file);
+            OutputStream out = new BufferedOutputStream(getFileManager().create(path, file));
             try {
                 IndentedPrintWriter writer = new IndentedPrintWriter(out);
 
@@ -123,7 +124,7 @@ public class JavaGenerator extends Generator {
                    .stream().anyMatch(t -> t.getName().equals("FACTORY_ID"))) {
 
             String file = helper.getHazelcastFactoryClassName(program) + ".java";
-            OutputStream out = getFileManager().create(path, file);
+            OutputStream out = new BufferedOutputStream(getFileManager().create(path, file));
             try {
                 IndentedPrintWriter writer = new IndentedPrintWriter(out);
 
@@ -142,7 +143,7 @@ public class JavaGenerator extends Generator {
 
         for (PDeclaredDescriptor<?> type : program.getDeclaredTypes()) {
             String file = JUtils.getClassName(type) + ".java";
-            OutputStream out = getFileManager().create(path, file);
+            OutputStream out = new BufferedOutputStream(getFileManager().create(path, file));
             try {
                 IndentedPrintWriter writer = new IndentedPrintWriter(out);
 
@@ -171,7 +172,7 @@ public class JavaGenerator extends Generator {
 
         for (CService service : program.getServices()) {
             String file = JUtils.getClassName(service) + ".java";
-            OutputStream out = getFileManager().create(path, file);
+            OutputStream out = new BufferedOutputStream(getFileManager().create(path, file));
             try {
                 IndentedPrintWriter writer = new IndentedPrintWriter(out);
                 appendFileHeader(writer, program);


### PR DESCRIPTION
Code generation seemed to take surprisingly long.  A profiler
identifed `Utf8StreamWriter#writeCodePoint()` as a hot spot.
Inspecting higher up the call stack revealed that unbuffered streams
were used.  The author of `Utf8StreamWriter` had the insight to
suggest supplying a buffered stream, but unfortunately the author
of `JavaGenerator` did not abide :-)

Applying this patch locally reduced code generation time significantly.