### PR TITLE
Add setter method overloads for _Builder types

### DIFF
--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/ContainerService.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/ContainerService.java
@@ -546,6 +546,17 @@ public class ContainerService {
             }
 
             /**
+             * Sets the value of c.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setC(net.morimekta.test.providence.core.Containers._Builder builder) {
+              return setC(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the c field.
              *
              * @return True if c has been set.
@@ -761,8 +772,24 @@ public class ContainerService {
          * @param value The union value
          * @return The created union.
          */
+        public static _load_response withSuccess(net.morimekta.test.providence.core.CompactFields._Builder value) {
+            return withSuccess(value == null ? null : value.build());
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
         public static _load_response withEf(net.morimekta.test.providence.core.ExceptionFields value) {
             return new _Builder().setEf(value).build();
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
+        public static _load_response withEf(net.morimekta.test.providence.core.ExceptionFields._Builder value) {
+            return withEf(value == null ? null : value.build());
         }
 
         private _load_response(_Builder builder) {
@@ -1173,6 +1200,17 @@ public class ContainerService {
             }
 
             /**
+             * Sets the value of success.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setSuccess(net.morimekta.test.providence.core.CompactFields._Builder builder) {
+              return setSuccess(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the success field.
              *
              * @return True if success has been set.
@@ -1250,6 +1288,17 @@ public class ContainerService {
                 mEf = value;
                 mEf_builder = null;
                 return this;
+            }
+
+            /**
+             * Sets the value of ef.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setEf(net.morimekta.test.providence.core.ExceptionFields._Builder builder) {
+              return setEf(builder == null ? null : builder.build());
             }
 
             /**

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/Containers.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/Containers.java
@@ -5466,6 +5466,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of requiredFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setRequiredFields(net.morimekta.test.providence.core.RequiredFields._Builder builder) {
+          return setRequiredFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the requiredFields field.
          *
          * @return True if requiredFields has been set.
@@ -5546,6 +5557,17 @@ public class Containers
             mDefaultFields = value;
             mDefaultFields_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of defaultFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setDefaultFields(net.morimekta.test.providence.core.DefaultFields._Builder builder) {
+          return setDefaultFields(builder == null ? null : builder.build());
         }
 
         /**
@@ -5632,6 +5654,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of optionalFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setOptionalFields(net.morimekta.test.providence.core.OptionalFields._Builder builder) {
+          return setOptionalFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the optionalFields field.
          *
          * @return True if optionalFields has been set.
@@ -5712,6 +5745,17 @@ public class Containers
             mUnionFields = value;
             mUnionFields_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of unionFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setUnionFields(net.morimekta.test.providence.core.UnionFields._Builder builder) {
+          return setUnionFields(builder == null ? null : builder.build());
         }
 
         /**
@@ -5798,6 +5842,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of exceptionFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setExceptionFields(net.morimekta.test.providence.core.ExceptionFields._Builder builder) {
+          return setExceptionFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the exceptionFields field.
          *
          * @return True if exceptionFields has been set.
@@ -5878,6 +5933,17 @@ public class Containers
             mDefaultValues = value;
             mDefaultValues_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of defaultValues.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setDefaultValues(net.morimekta.test.providence.core.DefaultValues._Builder builder) {
+          return setDefaultValues(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/DefaultFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/DefaultFields.java
@@ -1232,6 +1232,17 @@ public class DefaultFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/DefaultValues.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/DefaultValues.java
@@ -1320,6 +1320,17 @@ public class DefaultValues
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/ExceptionFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/ExceptionFields.java
@@ -1322,6 +1322,17 @@ public class ExceptionFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/OptionalFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/OptionalFields.java
@@ -1318,6 +1318,17 @@ public class OptionalFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/RequiredFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/RequiredFields.java
@@ -1232,6 +1232,17 @@ public class RequiredFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/UnionFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/UnionFields.java
@@ -115,6 +115,14 @@ public class UnionFields
         return new _Builder().setCompactValue(value).build();
     }
 
+    /**
+     * @param value The union value
+     * @return The created union.
+     */
+    public static UnionFields withCompactValue(net.morimekta.test.providence.core.CompactFields._Builder value) {
+        return withCompactValue(value == null ? null : value.build());
+    }
+
     private UnionFields(_Builder builder) {
         tUnionField = builder.tUnionField;
 
@@ -1237,6 +1245,17 @@ public class UnionFields
             mCompactValue = value;
             mCompactValue_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/calculator/CalculateException.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/calculator/CalculateException.java
@@ -490,6 +490,17 @@ public class CalculateException
         }
 
         /**
+         * Sets the value of operation.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setOperation(net.morimekta.test.providence.core.calculator.Operation._Builder builder) {
+          return setOperation(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the operation field.
          *
          * @return True if operation has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/calculator/Calculator.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/calculator/Calculator.java
@@ -612,6 +612,17 @@ public class Calculator {
             }
 
             /**
+             * Sets the value of op.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setOp(net.morimekta.test.providence.core.calculator.Operation._Builder builder) {
+              return setOp(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the op field.
              *
              * @return True if op has been set.
@@ -827,8 +838,24 @@ public class Calculator {
          * @param value The union value
          * @return The created union.
          */
+        public static _calculate_response withSuccess(net.morimekta.test.providence.core.calculator.Operand._Builder value) {
+            return withSuccess(value == null ? null : value.build());
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
         public static _calculate_response withCe(net.morimekta.test.providence.core.calculator.CalculateException value) {
             return new _Builder().setCe(value).build();
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
+        public static _calculate_response withCe(net.morimekta.test.providence.core.calculator.CalculateException._Builder value) {
+            return withCe(value == null ? null : value.build());
         }
 
         private _calculate_response(_Builder builder) {
@@ -1239,6 +1266,17 @@ public class Calculator {
             }
 
             /**
+             * Sets the value of success.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setSuccess(net.morimekta.test.providence.core.calculator.Operand._Builder builder) {
+              return setSuccess(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the success field.
              *
              * @return True if success has been set.
@@ -1316,6 +1354,17 @@ public class Calculator {
                 mCe = value;
                 mCe_builder = null;
                 return this;
+            }
+
+            /**
+             * Sets the value of ce.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setCe(net.morimekta.test.providence.core.calculator.CalculateException._Builder builder) {
+              return setCe(builder == null ? null : builder.build());
             }
 
             /**

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/calculator/Operand.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/calculator/Operand.java
@@ -35,6 +35,14 @@ public class Operand
      * @param value The union value
      * @return The created union.
      */
+    public static Operand withOperation(net.morimekta.test.providence.core.calculator.Operation._Builder value) {
+        return withOperation(value == null ? null : value.build());
+    }
+
+    /**
+     * @param value The union value
+     * @return The created union.
+     */
     public static Operand withNumber(double value) {
         return new _Builder().setNumber(value).build();
     }
@@ -45,6 +53,14 @@ public class Operand
      */
     public static Operand withImaginary(net.morimekta.test.providence.core.number.Imaginary value) {
         return new _Builder().setImaginary(value).build();
+    }
+
+    /**
+     * @param value The union value
+     * @return The created union.
+     */
+    public static Operand withImaginary(net.morimekta.test.providence.core.number.Imaginary._Builder value) {
+        return withImaginary(value == null ? null : value.build());
     }
 
     private Operand(_Builder builder) {
@@ -493,6 +509,17 @@ public class Operand
         }
 
         /**
+         * Sets the value of operation.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setOperation(net.morimekta.test.providence.core.calculator.Operation._Builder builder) {
+          return setOperation(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the operation field.
          *
          * @return True if operation has been set.
@@ -615,6 +642,17 @@ public class Operand
             mImaginary = value;
             mImaginary_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of imaginary.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setImaginary(net.morimekta.test.providence.core.number.Imaginary._Builder builder) {
+          return setImaginary(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/ContainerService.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/ContainerService.java
@@ -530,6 +530,17 @@ public class ContainerService {
             }
 
             /**
+             * Sets the value of c.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setC(net.morimekta.test.providence.core.no_rw_binary.Containers._Builder builder) {
+              return setC(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the c field.
              *
              * @return True if c has been set.
@@ -720,8 +731,24 @@ public class ContainerService {
          * @param value The union value
          * @return The created union.
          */
+        public static _load_response withSuccess(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder value) {
+            return withSuccess(value == null ? null : value.build());
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
         public static _load_response withEf(net.morimekta.test.providence.core.no_rw_binary.ExceptionFields value) {
             return new _Builder().setEf(value).build();
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
+        public static _load_response withEf(net.morimekta.test.providence.core.no_rw_binary.ExceptionFields._Builder value) {
+            return withEf(value == null ? null : value.build());
         }
 
         private _load_response(_Builder builder) {
@@ -1106,6 +1133,17 @@ public class ContainerService {
             }
 
             /**
+             * Sets the value of success.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setSuccess(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder builder) {
+              return setSuccess(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the success field.
              *
              * @return True if success has been set.
@@ -1183,6 +1221,17 @@ public class ContainerService {
                 mEf = value;
                 mEf_builder = null;
                 return this;
+            }
+
+            /**
+             * Sets the value of ef.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setEf(net.morimekta.test.providence.core.no_rw_binary.ExceptionFields._Builder builder) {
+              return setEf(builder == null ? null : builder.build());
             }
 
             /**

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/Containers.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/Containers.java
@@ -4804,6 +4804,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of requiredFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setRequiredFields(net.morimekta.test.providence.core.no_rw_binary.RequiredFields._Builder builder) {
+          return setRequiredFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the requiredFields field.
          *
          * @return True if requiredFields has been set.
@@ -4884,6 +4895,17 @@ public class Containers
             mDefaultFields = value;
             mDefaultFields_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of defaultFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setDefaultFields(net.morimekta.test.providence.core.no_rw_binary.DefaultFields._Builder builder) {
+          return setDefaultFields(builder == null ? null : builder.build());
         }
 
         /**
@@ -4970,6 +4992,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of optionalFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setOptionalFields(net.morimekta.test.providence.core.no_rw_binary.OptionalFields._Builder builder) {
+          return setOptionalFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the optionalFields field.
          *
          * @return True if optionalFields has been set.
@@ -5050,6 +5083,17 @@ public class Containers
             mUnionFields = value;
             mUnionFields_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of unionFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setUnionFields(net.morimekta.test.providence.core.no_rw_binary.UnionFields._Builder builder) {
+          return setUnionFields(builder == null ? null : builder.build());
         }
 
         /**
@@ -5136,6 +5180,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of exceptionFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setExceptionFields(net.morimekta.test.providence.core.no_rw_binary.ExceptionFields._Builder builder) {
+          return setExceptionFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the exceptionFields field.
          *
          * @return True if exceptionFields has been set.
@@ -5216,6 +5271,17 @@ public class Containers
             mDefaultValues = value;
             mDefaultValues_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of defaultValues.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setDefaultValues(net.morimekta.test.providence.core.no_rw_binary.DefaultValues._Builder builder) {
+          return setDefaultValues(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/DefaultFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/DefaultFields.java
@@ -1175,6 +1175,17 @@ public class DefaultFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/DefaultValues.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/DefaultValues.java
@@ -1247,6 +1247,17 @@ public class DefaultValues
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/ExceptionFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/ExceptionFields.java
@@ -1265,6 +1265,17 @@ public class ExceptionFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/OptionalFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/OptionalFields.java
@@ -1245,6 +1245,17 @@ public class OptionalFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/RequiredFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/RequiredFields.java
@@ -1175,6 +1175,17 @@ public class RequiredFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/UnionFields.java
+++ b/providence-core/src/test/java-gen/net/morimekta/test/providence/core/no_rw_binary/UnionFields.java
@@ -114,6 +114,14 @@ public class UnionFields
         return new _Builder().setCompactValue(value).build();
     }
 
+    /**
+     * @param value The union value
+     * @return The created union.
+     */
+    public static UnionFields withCompactValue(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder value) {
+        return withCompactValue(value == null ? null : value.build());
+    }
+
     private UnionFields(_Builder builder) {
         tUnionField = builder.tUnionField;
 
@@ -1159,6 +1167,17 @@ public class UnionFields
             mCompactValue = value;
             mCompactValue_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.core.no_rw_binary.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/BuilderCommonMemberFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/BuilderCommonMemberFormatter.java
@@ -346,7 +346,7 @@ public class BuilderCommonMemberFormatter implements MessageMemberFormatter {
         }
         writer.appendln(JAnnotation.NON_NULL);
         writer.formatln("public _Builder %s(%s builder) {", field.setter(), field.builderMutableType());
-        writer.formatln("  return %s(builder.build());", field.setter());
+        writer.formatln("  return %s(builder == null ? null : builder.build());", field.setter());
         writer.formatln("}");
         writer.newline();
     }

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonMemberFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonMemberFormatter.java
@@ -20,6 +20,7 @@
  */
 package net.morimekta.providence.generator.format.java.messages;
 
+import net.morimekta.providence.PType;
 import net.morimekta.providence.generator.GeneratorException;
 import net.morimekta.providence.generator.GeneratorOptions;
 import net.morimekta.providence.generator.format.java.JavaOptions;
@@ -346,6 +347,25 @@ public class CommonMemberFormatter implements MessageMemberFormatter {
               .newline();
     }
 
+    private void appendCreateConstructorBuilderOverload(JMessage<?> message, JField field) {
+        BlockCommentBuilder block = new BlockCommentBuilder(writer);
+        if (field.hasComment()) {
+            block.comment(field.comment());
+        }
+        block.param_("value", "The union value")
+             .return_("The created union.")
+             .finish();
+        writer.formatln("public static %s %s(%s value) {",
+                        message.instanceType(),
+                        camelCase("with", field.name()),
+                        field.builderMutableType())
+              .begin()
+              .formatln("return %s(value.build());", camelCase("with", field.name()))
+              .end()
+              .appendln('}')
+              .newline();
+    }
+
     private void appendCreateConstructor(JMessage<?> message) throws GeneratorException {
         if (message.isUnion()) {
             for (JField field : message.declaredOrderFields()) {
@@ -377,6 +397,10 @@ public class CommonMemberFormatter implements MessageMemberFormatter {
                           .end()
                           .appendln('}')
                           .newline();
+
+                    if (field.type() == PType.MESSAGE) {
+                        appendCreateConstructorBuilderOverload(message, field);
+                    }
                 }
             }
         } else {

--- a/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonMemberFormatter.java
+++ b/providence-generator-java/src/main/java/net/morimekta/providence/generator/format/java/messages/CommonMemberFormatter.java
@@ -360,7 +360,7 @@ public class CommonMemberFormatter implements MessageMemberFormatter {
                         camelCase("with", field.name()),
                         field.builderMutableType())
               .begin()
-              .formatln("return %s(value.build());", camelCase("with", field.name()))
+              .formatln("return %s(value == null ? null : value.build());", camelCase("with", field.name()))
               .end()
               .appendln('}')
               .newline();

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/ContainerService.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/ContainerService.java
@@ -546,6 +546,17 @@ public class ContainerService {
             }
 
             /**
+             * Sets the value of c.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setC(net.morimekta.test.providence.reflect.Containers._Builder builder) {
+              return setC(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the c field.
              *
              * @return True if c has been set.
@@ -761,8 +772,24 @@ public class ContainerService {
          * @param value The union value
          * @return The created union.
          */
+        public static _load_response withSuccess(net.morimekta.test.providence.reflect.CompactFields._Builder value) {
+            return withSuccess(value == null ? null : value.build());
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
         public static _load_response withEf(net.morimekta.test.providence.reflect.ExceptionFields value) {
             return new _Builder().setEf(value).build();
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
+        public static _load_response withEf(net.morimekta.test.providence.reflect.ExceptionFields._Builder value) {
+            return withEf(value == null ? null : value.build());
         }
 
         private _load_response(_Builder builder) {
@@ -1173,6 +1200,17 @@ public class ContainerService {
             }
 
             /**
+             * Sets the value of success.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setSuccess(net.morimekta.test.providence.reflect.CompactFields._Builder builder) {
+              return setSuccess(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the success field.
              *
              * @return True if success has been set.
@@ -1250,6 +1288,17 @@ public class ContainerService {
                 mEf = value;
                 mEf_builder = null;
                 return this;
+            }
+
+            /**
+             * Sets the value of ef.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setEf(net.morimekta.test.providence.reflect.ExceptionFields._Builder builder) {
+              return setEf(builder == null ? null : builder.build());
             }
 
             /**

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/Containers.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/Containers.java
@@ -5198,6 +5198,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of requiredFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setRequiredFields(net.morimekta.test.providence.reflect.RequiredFields._Builder builder) {
+          return setRequiredFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the requiredFields field.
          *
          * @return True if requiredFields has been set.
@@ -5278,6 +5289,17 @@ public class Containers
             mDefaultFields = value;
             mDefaultFields_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of defaultFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setDefaultFields(net.morimekta.test.providence.reflect.DefaultFields._Builder builder) {
+          return setDefaultFields(builder == null ? null : builder.build());
         }
 
         /**
@@ -5364,6 +5386,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of optionalFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setOptionalFields(net.morimekta.test.providence.reflect.OptionalFields._Builder builder) {
+          return setOptionalFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the optionalFields field.
          *
          * @return True if optionalFields has been set.
@@ -5444,6 +5477,17 @@ public class Containers
             mUnionFields = value;
             mUnionFields_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of unionFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setUnionFields(net.morimekta.test.providence.reflect.UnionFields._Builder builder) {
+          return setUnionFields(builder == null ? null : builder.build());
         }
 
         /**
@@ -5530,6 +5574,17 @@ public class Containers
         }
 
         /**
+         * Sets the value of exceptionFields.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setExceptionFields(net.morimekta.test.providence.reflect.ExceptionFields._Builder builder) {
+          return setExceptionFields(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the exceptionFields field.
          *
          * @return True if exceptionFields has been set.
@@ -5610,6 +5665,17 @@ public class Containers
             mDefaultValues = value;
             mDefaultValues_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of defaultValues.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setDefaultValues(net.morimekta.test.providence.reflect.DefaultValues._Builder builder) {
+          return setDefaultValues(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/DefaultFields.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/DefaultFields.java
@@ -1232,6 +1232,17 @@ public class DefaultFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.reflect.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/DefaultValues.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/DefaultValues.java
@@ -1320,6 +1320,17 @@ public class DefaultValues
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.reflect.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/ExceptionFields.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/ExceptionFields.java
@@ -1322,6 +1322,17 @@ public class ExceptionFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.reflect.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/OptionalFields.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/OptionalFields.java
@@ -1318,6 +1318,17 @@ public class OptionalFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.reflect.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/RequiredFields.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/RequiredFields.java
@@ -1232,6 +1232,17 @@ public class RequiredFields
         }
 
         /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.reflect.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the compactValue field.
          *
          * @return True if compactValue has been set.

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/UnionFields.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/UnionFields.java
@@ -115,6 +115,14 @@ public class UnionFields
         return new _Builder().setCompactValue(value).build();
     }
 
+    /**
+     * @param value The union value
+     * @return The created union.
+     */
+    public static UnionFields withCompactValue(net.morimekta.test.providence.reflect.CompactFields._Builder value) {
+        return withCompactValue(value == null ? null : value.build());
+    }
+
     private UnionFields(_Builder builder) {
         tUnionField = builder.tUnionField;
 
@@ -1237,6 +1245,17 @@ public class UnionFields
             mCompactValue = value;
             mCompactValue_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of compactValue.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setCompactValue(net.morimekta.test.providence.reflect.CompactFields._Builder builder) {
+          return setCompactValue(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/calculator/CalculateException.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/calculator/CalculateException.java
@@ -490,6 +490,17 @@ public class CalculateException
         }
 
         /**
+         * Sets the value of operation.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setOperation(net.morimekta.test.providence.reflect.calculator.Operation._Builder builder) {
+          return setOperation(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the operation field.
          *
          * @return True if operation has been set.

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/calculator/Calculator.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/calculator/Calculator.java
@@ -612,6 +612,17 @@ public class Calculator {
             }
 
             /**
+             * Sets the value of op.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setOp(net.morimekta.test.providence.reflect.calculator.Operation._Builder builder) {
+              return setOp(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the op field.
              *
              * @return True if op has been set.
@@ -827,8 +838,24 @@ public class Calculator {
          * @param value The union value
          * @return The created union.
          */
+        public static _calculate_response withSuccess(net.morimekta.test.providence.reflect.calculator.Operand._Builder value) {
+            return withSuccess(value == null ? null : value.build());
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
         public static _calculate_response withCe(net.morimekta.test.providence.reflect.calculator.CalculateException value) {
             return new _Builder().setCe(value).build();
+        }
+
+        /**
+         * @param value The union value
+         * @return The created union.
+         */
+        public static _calculate_response withCe(net.morimekta.test.providence.reflect.calculator.CalculateException._Builder value) {
+            return withCe(value == null ? null : value.build());
         }
 
         private _calculate_response(_Builder builder) {
@@ -1239,6 +1266,17 @@ public class Calculator {
             }
 
             /**
+             * Sets the value of success.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setSuccess(net.morimekta.test.providence.reflect.calculator.Operand._Builder builder) {
+              return setSuccess(builder == null ? null : builder.build());
+            }
+
+            /**
              * Checks for presence of the success field.
              *
              * @return True if success has been set.
@@ -1316,6 +1354,17 @@ public class Calculator {
                 mCe = value;
                 mCe_builder = null;
                 return this;
+            }
+
+            /**
+             * Sets the value of ce.
+             *
+             * @param builder builder for the new value
+             * @return The builder
+             */
+            @javax.annotation.Nonnull
+            public _Builder setCe(net.morimekta.test.providence.reflect.calculator.CalculateException._Builder builder) {
+              return setCe(builder == null ? null : builder.build());
             }
 
             /**

--- a/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/calculator/Operand.java
+++ b/providence-reflect/src/test/java-gen/net/morimekta/test/providence/reflect/calculator/Operand.java
@@ -35,6 +35,14 @@ public class Operand
      * @param value The union value
      * @return The created union.
      */
+    public static Operand withOperation(net.morimekta.test.providence.reflect.calculator.Operation._Builder value) {
+        return withOperation(value == null ? null : value.build());
+    }
+
+    /**
+     * @param value The union value
+     * @return The created union.
+     */
     public static Operand withNumber(double value) {
         return new _Builder().setNumber(value).build();
     }
@@ -45,6 +53,14 @@ public class Operand
      */
     public static Operand withImaginary(net.morimekta.test.providence.reflect.number.Imaginary value) {
         return new _Builder().setImaginary(value).build();
+    }
+
+    /**
+     * @param value The union value
+     * @return The created union.
+     */
+    public static Operand withImaginary(net.morimekta.test.providence.reflect.number.Imaginary._Builder value) {
+        return withImaginary(value == null ? null : value.build());
     }
 
     private Operand(_Builder builder) {
@@ -493,6 +509,17 @@ public class Operand
         }
 
         /**
+         * Sets the value of operation.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setOperation(net.morimekta.test.providence.reflect.calculator.Operation._Builder builder) {
+          return setOperation(builder == null ? null : builder.build());
+        }
+
+        /**
          * Checks for presence of the operation field.
          *
          * @return True if operation has been set.
@@ -615,6 +642,17 @@ public class Operand
             mImaginary = value;
             mImaginary_builder = null;
             return this;
+        }
+
+        /**
+         * Sets the value of imaginary.
+         *
+         * @param builder builder for the new value
+         * @return The builder
+         */
+        @javax.annotation.Nonnull
+        public _Builder setImaginary(net.morimekta.test.providence.reflect.number.Imaginary._Builder builder) {
+          return setImaginary(builder == null ? null : builder.build());
         }
 
         /**

--- a/providence-testing/src/test/java/net/morimekta/providence/gentests/ProvidenceTest.java
+++ b/providence-testing/src/test/java/net/morimekta/providence/gentests/ProvidenceTest.java
@@ -338,6 +338,26 @@ public class ProvidenceTest {
     }
 
     @Test
+    public void testUnionConstructorOverload() {
+        assertThat(UnionFields.withCompactValue((CompactFields._Builder) null),
+                   is(UnionFields.withCompactValue((CompactFields) null)));
+        assertThat(UnionFields.withCompactValue(CompactFields.builder()),
+                   is(UnionFields.withCompactValue(CompactFields.builder().build())));
+        assertThat(UnionFields.withCompactValue(CompactFields.builder().setName("a").setId(4)),
+                   is(UnionFields.withCompactValue(new CompactFields("a", 4, null))));
+    }
+
+    @Test
+    public void testMessageSetterOverload() {
+        assertThat(OptionalFields.builder().setCompactValue((CompactFields._Builder) null).build(),
+                   is(OptionalFields.builder().setCompactValue((CompactFields) null).build()));
+
+        CompactFields._Builder cf = CompactFields.builder().setName("a").setId(4);
+        assertThat(OptionalFields.builder().setCompactValue(cf).build(),
+                   is(OptionalFields.builder().setCompactValue(cf.build()).build()));
+    }
+
+    @Test
     public void testSerializable() throws IOException, ClassNotFoundException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);


### PR DESCRIPTION
Removes boilerplate when constructing complex builder objects.  For example:

```java
Person person = Person.builder()
    .setName(Name.builder().setValue("Larry").build())
    .setBirthDate(Date.builder().setUnixTime(birthDate).build())
    .build()
```
can be reduced to:
```java
Person person = Person.builder()
    .setName(Name.builder().setValue("Larry"))
    .setBirthDate(Date.builder().setUnixTime(birthDate))
    .build()
```

This could be extended to the `.addToX()` methods for collections, but i opted to pause here and check for consensus on the approach.