### PR TITLE
Fix most test breakages on macOS

### DIFF
--- a/providence-core-client/src/test/java/net/morimekta/providence/client/HttpClientHandlerNetworkTest.java
+++ b/providence-core-client/src/test/java/net/morimekta/providence/client/HttpClientHandlerNetworkTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
@@ -132,7 +133,7 @@ public class HttpClientHandlerNetworkTest {
         } catch (SocketException ex) {
             // TODO: This should be a HttpResponseException
             assertThat(ex.getMessage(), anyOf(
-                    is("Broken pipe (Write failed)"),
+                    containsString("Broken pipe"),
                     is("Connection reset"),
                     is("Software caused connection abort: socket write error")));
         }

--- a/providence-reflect/src/test/java/net/morimekta/providence/reflect/TypeLoaderTest.java
+++ b/providence-reflect/src/test/java/net/morimekta/providence/reflect/TypeLoaderTest.java
@@ -74,7 +74,8 @@ public class TypeLoaderTest {
             loader.load(folder);
             fail("no exception");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("Unable to load thrift program: " + folder.toString() + " is not a file."));
+            assertThat(e.getMessage(),
+                       is("Unable to load thrift program: " + folder.getCanonicalFile() + " is not a file."));
         }
 
         File noFile = new File(temp.getRoot(), "boo");
@@ -82,7 +83,8 @@ public class TypeLoaderTest {
             loader.load(noFile);
             fail("no exception");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("Unable to load thrift program: " + noFile.toString() + " is not a file."));
+            assertThat(e.getMessage(),
+                       is("Unable to load thrift program: " + noFile.getCanonicalFile() + " is not a file."));
         }
 
         try {

--- a/providence-reflect/src/test/java/net/morimekta/providence/reflect/contained/CServiceMethodTest.java
+++ b/providence-reflect/src/test/java/net/morimekta/providence/reflect/contained/CServiceMethodTest.java
@@ -62,12 +62,12 @@ public class CServiceMethodTest {
 
         ProgramType program = parser.parse(new FileInputStream(numeric),
                                            numeric, ImmutableList.of(tmp.getRoot()));
-        registry.putProgram(numeric.getPath(), converter.convert(numeric.getPath(), program));
+        registry.putProgram(numeric.getCanonicalPath(), converter.convert(numeric.getCanonicalPath(), program));
         program = parser.parse(new FileInputStream(calculator),
                                calculator, ImmutableList.of(tmp.getRoot()));
-        registry.putProgram(calculator.getPath(), converter.convert(calculator.getPath(), program));
+        registry.putProgram(calculator.getCanonicalPath(), converter.convert(calculator.getCanonicalPath(), program));
 
-        this.registry = registry.registryForPath(calculator.getCanonicalFile().getAbsolutePath());
+        this.registry = registry.registryForPath(calculator.getCanonicalPath());
     }
 
     @Test

--- a/providence-reflect/src/test/java/net/morimekta/providence/reflect/contained/CServiceTest.java
+++ b/providence-reflect/src/test/java/net/morimekta/providence/reflect/contained/CServiceTest.java
@@ -60,12 +60,12 @@ public class CServiceTest {
 
         ProgramType program = parser.parse(new FileInputStream(numeric),
                                            numeric, ImmutableList.of(tmp.getRoot()));
-        registry.putProgram(numeric.getPath(), converter.convert(numeric.getPath(), program));
+        registry.putProgram(numeric.getCanonicalPath(), converter.convert(numeric.getCanonicalPath(), program));
         program = parser.parse(new FileInputStream(calculator),
                                calculator, ImmutableList.of(tmp.getRoot()));
-        registry.putProgram(calculator.getPath(), converter.convert(calculator.getPath(), program));
+        registry.putProgram(calculator.getCanonicalPath(), converter.convert(calculator.getCanonicalPath(), program));
 
-        this.registry = registry.registryForPath(calculator.getCanonicalFile().getAbsolutePath());
+        this.registry = registry.registryForPath(calculator.getCanonicalPath());
     }
 
     @Test

--- a/providence-tools-compiler/src/test/java/net/morimekta/providence/tools/compiler/CompilerFlagsTest.java
+++ b/providence-tools-compiler/src/test/java/net/morimekta/providence/tools/compiler/CompilerFlagsTest.java
@@ -115,9 +115,9 @@ public class CompilerFlagsTest {
     @Test
     public void testIncludeNotADirectory() throws IOException {
         sut.run("-I",
-                thriftFile.getAbsolutePath(),
+                thriftFile.getCanonicalPath(),
                 "-g", "java",
-                thriftFile.getAbsolutePath());
+                thriftFile.getCanonicalPath());
 
         assertThat(console.output(), is(""));
         assertThat(console.error(),

--- a/providence-tools-converter/src/test/java/net/morimekta/providence/tools/converter/ConvertTest.java
+++ b/providence-tools-converter/src/test/java/net/morimekta/providence/tools/converter/ConvertTest.java
@@ -94,7 +94,7 @@ public class ConvertTest {
     }
 
     @Test
-    public void testListTypes() {
+    public void testListTypes() throws IOException {
         convert.run(
                 "-I", temp.getRoot().getAbsolutePath(),
                 "--list-types",
@@ -102,7 +102,7 @@ public class ConvertTest {
 
         assertThat(console.error(), is(""));
         assertThat(console.output(), is(equalToLines(
-                temp.getRoot().toString() + "/cont.thrift:\n" +
+                temp.getRoot().getCanonicalPath() + "/cont.thrift:\n" +
                 "  struct    cont.CompactFields\n" +
                 "  struct    cont.OptionalFields\n" +
                 "  struct    cont.RequiredFields\n" +


### PR DESCRIPTION
Most of the issues were related to asymmetry between use of absolute and canonical paths.  The latter resolves symlinks, and macOS uses a symlink for the default TMPDIR.  I suspect Linux users with a symlinked TMPDIR would be affected as well, but i haven't tested this.

There is a nasty hack around a test that expects a native and sane `WatchService`, which is not the case on macOS (or Windows, apparently).  I was on the fence whether to just exit early from these test cases when `PollingWatchService` is used; your call.

The remaining failing tests are related to Hazelcast:
- `net.morimekta.providence.gentests.HazelcastIT`, `net.morimekta.hazelcast.it.*`
```
testListEntitiesHazelcast(net.morimekta.providence.gentests.HazelcastIT)  Time elapsed: 0.591 sec  <<< ERROR!
java.lang.NullPointerException
        at net.morimekta.providence.gentests.HazelcastIT.testListEntitiesHazelcast(HazelcastIT.java:91)

testBaseEntitiesHazelcast(net.morimekta.providence.gentests.HazelcastIT)  Time elapsed: 0.028 sec  <<< ERROR!
java.lang.NullPointerException
        at net.morimekta.providence.gentests.HazelcastIT.testBaseEntitiesHazelcast(HazelcastIT.java:77)
```

I'm interested if you have any thoughts on getting these working.